### PR TITLE
Fix generated build secrets compilation

### DIFF
--- a/VRCNext.csproj
+++ b/VRCNext.csproj
@@ -55,6 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="BuildSecrets.cs" />
+    <Compile Include="BuildSecrets.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
   <None Update="voice\**\*">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </None>

--- a/main/AppShell.cs
+++ b/main/AppShell.cs
@@ -488,6 +488,8 @@ public partial class AppShell
 
     private static string DecryptWebhook()
     {
+        if (_whKey.Length == 0) return "";
+
         var b = new byte[_whEnc.Length];
         for (int i = 0; i < b.Length; i++)
             b[i] = (byte)(_whEnc[i] ^ _whKey[i % _whKey.Length]);


### PR DESCRIPTION
## Summary

  Fixes clean builds by making the generated `BuildSecrets.cs` file participate in compilation and by safely handling builds
  where no webhook key is provided.

  ## Problem

  A clean checkout of `upstream/main` fails to build because `AppShell.cs` references `BuildSecrets`, but `BuildSecrets.cs`
  is generated by an MSBuild target before compile. Since SDK-style projects discover `*.cs` files during project evaluation,
  the generated file is not included in the compile item list on a fresh checkout.

  Observed error:

  `main\AppShell.cs(487,81): error CS0103: The name 'BuildSecrets' does not exist in the current context`

  There is also a runtime edge case when `VRCNextWhKey` is unset: `BuildSecrets.WhKey` becomes empty, and crash-report
  webhook decryption can divide by zero when indexing `_whKey`.

  ## Changes

  - Explicitly includes `BuildSecrets.cs` in `VRCNext.csproj` so the generated file is compiled on clean builds.
  - Adds a guard in `DecryptWebhook()` to return an empty string when no webhook key is available.

  ## Testing

  Tested a fresh `upstream/main` worktree:

  `dotnet build VRCNext.sln`

  Result before this fix:

  `CS0103: The name 'BuildSecrets' does not exist in the current context`

  Tested this branch:

  `dotnet build VRCNext.sln --no-restore`

  Result after this fix:

  `0 Error(s)`

  ## Note

  This change was originally part of #38 , but I split it into its own focused PR because it fixes an independent
  clean-build issue.

  ## AI Assistance Disclosure

  AI assistance was used to help inspect the build failure, reason through the MSBuild generated-file timing issue, and draft
  this PR description. The code change was reviewed and tested locally before submission.