### PR TITLE
Fix/tooltip positioning

### DIFF
--- a/VRCNext.csproj
+++ b/VRCNext.csproj
@@ -55,6 +55,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="BuildSecrets.cs" />
+    <Compile Include="BuildSecrets.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
   <None Update="voice\**\*">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </None>

--- a/frontend/core/hover/hover.js
+++ b/frontend/core/hover/hover.js
@@ -22,12 +22,24 @@
         tip.style.left = '-9999px';
         tip.style.top  = '-9999px';
         requestAnimationFrame(() => {
+            const matrix = new DOMMatrixReadOnly(getComputedStyle(document.body).transform);
+            const zoom = matrix.a || 1;
+            const viewW = window.innerWidth / zoom;
+            const viewH = window.innerHeight / zoom;
+            const tipRect = {
+                left: rect.left / zoom,
+                top: rect.top / zoom,
+                right: rect.right / zoom,
+                bottom: rect.bottom / zoom,
+                width: rect.width / zoom,
+                height: rect.height / zoom,
+            };
             const tw = tip.offsetWidth;
             const th = tip.offsetHeight;
-            let left = rect.left + rect.width / 2 - tw / 2;
-            let top  = rect.bottom + 7;
-            if (top + th > window.innerHeight - 8) top = rect.top - th - 7;
-            left = Math.max(8, Math.min(left, window.innerWidth - tw - 8));
+            let left = tipRect.left + tipRect.width / 2 - tw / 2;
+            let top  = tipRect.bottom + 7;
+            if (top + th > viewH - 8) top = tipRect.top - th - 7;
+            left = Math.max(8, Math.min(left, viewW - tw - 8));
             tip.style.left = left + 'px';
             tip.style.top  = top + 'px';
         });

--- a/main/AppShell.cs
+++ b/main/AppShell.cs
@@ -488,6 +488,8 @@ public partial class AppShell
 
     private static string DecryptWebhook()
     {
+        if (_whKey.Length == 0) return "";
+
         var b = new byte[_whEnc.Length];
         for (int i = 0; i < b.Length; i++)
             b[i] = (byte)(_whEnc[i] ^ _whKey[i % _whKey.Length]);


### PR DESCRIPTION
  ## Summary

  Fixes tooltip positioning when GUI zoom is changed.

  ## Problem

  Tooltips were positioned using viewport coordinates from `getBoundingClientRect()`, but the tooltip element lives inside the scaled
`document.body`. At non-100% GUI zoom, that caused tooltips to appear offset from their target instead of centered.

  ## Changes

  - Reads the current body transform scale.
  - Converts tooltip target coordinates through that scale before assigning `left` and `top`.
  - Keeps existing tooltip clamping behavior at viewport edges.

  ## Testing

  - Tested tooltip behavior at normal and adjusted GUI zoom levels.
  - Ran `node --check frontend/core/hover/hover.js`.
  - Ran `dotnet build VRCNext.sln --no-restore`.

  Result after this fix:

  `0 Error(s)`

  ## Note

  This branch is stacked on `fix/build-clean` because a clean checkout of `upstream/main` currently fails to build with `CS0103: The name
'BuildSecrets' does not exist in the current context`. Once `fix/build-clean` is merged, I can rebase this branch onto upstream `main` so this
PR contains only the tooltip positioning change previously included in #38 

  ## AI Assistance Disclosure

  AI assistance was used to help inspect the tooltip positioning issue, reason through the GUI scaling behavior, and draft this PR description.
The code change was reviewed and tested locally before submission.
