### PR TITLE
2026.35.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,13 @@
 **2026.35.4**
 
+**Photo Modal**
+* Hidden or blurred images now remain blurred when opened, preventing accidental clicks and photo leaks. Click the image again to reveal it.
+* Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.
+
 **Design Refactor**
 * All modals now use the new header menu with action buttons, matching the design of the updated profile modals.
 * Avatar, Profile, Group, and World modals are now slightly taller and wider to display more content.
+* Refactored the **Timeline > Friends > Location** modal to match the design of the **Personal Instances** modal.
 
 **Bug Fixes**
 * Fixed the **Close**, **Customize Profile**, and **Change Banner** buttons appearing inside your own profile modal instead of in the taskbar when **Use Direct Modal Navigation** is disabled.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@
 * Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.
 * All images that can be inspected in any modal do use now the photo modal so you can resize, zoom-in/out/rotate and download the image and have a better "inspecting" experience.
 
+**Timeline**
+* Photo, Instance and Location modals do support breadcrumb navigation.
+
 **Design Refactor**
 * All modals now use the new header menu with action buttons, matching the design of the updated profile modals.
 * Avatar, Profile, Group, and World modals are now slightly taller and wider to display more content.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 **2026.35.4**
 
+**VRC+ Decoration Improvements**
+* Added an option to improve readability on profiles with bad text colors.
+* Navbar badges do use icon color now on vrc+ decorated profiles.
+
 **Photo Modal**
 * Hidden or blurred images now remain blurred when opened, preventing accidental clicks and photo leaks. Click the image again to reveal it.
 * Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,28 +1,7 @@
-**2026.35.3**
+**2026.35.4**
 
-**User Profile Update**
-
-* Added support for the Compact and Classic designs on your own user profile.
-* Added a **Content** tab showing your own public and private avatars and worlds.
-* Added a **Groups** tab showing your owned and joined groups.
-* Added a **Favs.** tab showing your public and private favorite worlds.
-* Your own profile now has the same general layout and features as other user profiles.
-
-**VRChat Plus Decorations**
-
-* Added profile theme customization options for buttons, text, icons, and modal colors.
-* The button color selected in-game or in VRCNext also affects the modal color. For example, a bright blue button color will create a darker blue modal theme.
-* Added an option to make profile elements semi-transparent, allowing them to blend better with custom backgrounds.
-
-**Modal Navigation**
-
-* Modals now remember the last opened tab.
-* Breadcrumb navigation also remembers which tab was open in each modal. Returning to a profile, group, world, or avatar modal takes you back to the previously selected tab instead of resetting to the first one.
+**Design Refactor**
 
 **Bug Fixes**
 
-* Fixed profile status icons appearing behind VRC+ profile icon frame decorations.
-* Fixed status dots in profile modals appearing behind icon frame decorations.
-* Fixed moderation entries in the Timeline showing “Unknown” instead of the player’s name. Existing entries are filled in automatically the next time the Timeline loads.
-* Fixed #113 - using CTRl + Scroll / zoom in / zoom out caused buttons and text to be blurry.
-* Fixed status dots in profile modals.
+* Fixed Close, Customize Profile and Change banner buttons appearing inside your own profile modal instead of the taskbar when **Use Direct Modal Navigation** is disabled.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 **2026.35.4**
 
 **Design Refactor**
+* All Modals now use the new headline menu with option buttons so they match the design of the new profile modals.
 
 **Bug Fixes**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 **Design Refactor**
 * All Modals now use the new headline menu with option buttons so they match the design of the new profile modals.
+* Avatar, Profile, Group and World Modals are slightly higher to display more content.
 
 **Bug Fixes**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 **Photo Modal**
 * Hidden or blurred images now remain blurred when opened, preventing accidental clicks and photo leaks. Click the image again to reveal it.
 * Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.
+* All images that can be inspected in any modal do use now the photo modal so you can resize, zoom-in/out/rotate and download the image and have a better "inspecting" experience.
 
 **Design Refactor**
 * All modals now use the new header menu with action buttons, matching the design of the updated profile modals.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,8 @@
 **2026.35.4**
 
 **Design Refactor**
-* All Modals now use the new headline menu with option buttons so they match the design of the new profile modals.
-* Avatar, Profile, Group and World Modals are slightly higher to display more content.
+* All modals now use the new header menu with action buttons, matching the design of the updated profile modals.
+* Avatar, Profile, Group, and World modals are now slightly taller and wider to display more content.
 
 **Bug Fixes**
-
-* Fixed Close, Customize Profile and Change banner buttons appearing inside your own profile modal instead of the taskbar when **Use Direct Modal Navigation** is disabled.
+* Fixed the **Close**, **Customize Profile**, and **Change Banner** buttons appearing inside your own profile modal instead of in the taskbar when **Use Direct Modal Navigation** is disabled.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 **2026.35.4**
 
+**Group Modal**
+* See roles of group even if you aren't have permissions.
+
 **VRC+ Decoration Improvements**
 * Added an option to improve readability on profiles with bad text colors.
 * Navbar badges do use icon color now on vrc+ decorated profiles.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,3 +22,4 @@
 
 **Bug Fixes**
 * Fixed the **Close**, **Customize Profile**, and **Change Banner** buttons appearing inside your own profile modal instead of in the taskbar when **Use Direct Modal Navigation** is disabled.
+* Fixed Log "Type" text being to long in gorup logs.

--- a/Services/Services.cs
+++ b/Services/Services.cs
@@ -276,6 +276,7 @@ public class AppSettings
     public bool EnableProfileBackgrounds { get; set; } = false;
     public bool EnableProfileThemes { get; set; } = false;
     public bool ProfileThemeVrcnOverride { get; set; } = false;
+    public bool ProfileThemeContrast { get; set; } = true;
     public bool TransparentProfileCards { get; set; } = false;
     public bool ShowDecorationsOnDashboard { get; set; } = false;
     public string ProfileModalStyle { get; set; } = "classic";

--- a/frontend/Styles/profile-theme.css
+++ b/frontend/Styles/profile-theme.css
@@ -40,6 +40,11 @@
 }
 
 .has-profile-theme .vrcn-badge { background: #1C1C1F; }
+
+.has-profile-theme .vrcn-badge.fd-tab-badge {
+    background: var(--pt-icon, var(--accent));
+    color: var(--pt-icon-fg, #fff);
+}
 .has-profile-theme .fd-lang-tags .vrcn-badge { background: var(--bg-hover); }
 
 .has-profile-theme .vrcn-badge.public,

--- a/frontend/Styles/styles.css
+++ b/frontend/Styles/styles.css
@@ -661,6 +661,14 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     color: var(--tx2);
 }
 
+.fd-tab-badge {
+    background: var(--accent);
+    color: #fff;
+    font-size: 10px;
+    padding: 1px 5px;
+    margin-left: 4px;
+}
+
 .fd-vrc-badges {
     margin-bottom: 12px;
 }

--- a/frontend/core/Keybinds/keybind-modal.html
+++ b/frontend/core/Keybinds/keybind-modal.html
@@ -1,6 +1,9 @@
         <div class="modal-box" style="width:650px;max-width:90%;">
-            <div class="modal-title" style="margin-bottom:16px;" data-i18n="keybinds.modal.title">Keyboard Shortcuts</div>
-            <div class="kb-help-list">
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="keybinds.modal.title">Keyboard Shortcuts</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalKeybinds').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="kb-help-list" style="margin-top:20px;">
                 <div class="kb-help-row"><span data-i18n="keybinds.modal.smart_search">Open Smart Search</span><span class="vrcn-keybind">CTRL K</span></div>
                 <div class="kb-help-row"><span data-i18n="keybinds.modal.own_profile">Open Own Profile</span><span class="vrcn-keybind">CTRL P</span></div>
                 <div class="kb-help-row"><span data-i18n="keybinds.modal.user_status">Open User Status</span><span class="vrcn-keybind">CTRL I</span></div>

--- a/frontend/core/logic/profile-theme.js
+++ b/frontend/core/logic/profile-theme.js
@@ -25,6 +25,71 @@ function _ptShade(hex, factor) {
     return '#' + [r, g, b].map(v => Math.max(0, Math.min(255, v)).toString(16).padStart(2, '0')).join('');
 }
 
+function profileThemeContrastEnabled() {
+    return !(typeof settings !== 'undefined' && settings.profileThemeContrast === false);
+}
+
+function _ptToHex(value) {
+    const s = String(value || '').trim();
+    if (/^#[0-9a-f]{6}$/i.test(s)) return s.toLowerCase();
+    if (/^#[0-9a-f]{3}$/i.test(s)) return '#' + s.slice(1).split('').map(c => c + c).join('').toLowerCase();
+    const m = s.match(/^rgba?\(([^)]+)\)$/i);
+    if (m) {
+        const p = m[1].split(/[\s,/]+/).filter(Boolean).map(Number);
+        if (p.length >= 3 && p.slice(0, 3).every(n => isFinite(n))) {
+            return '#' + p.slice(0, 3).map(n => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0')).join('');
+        }
+    }
+    return '';
+}
+
+function _ptRgb(hex) {
+    const n = parseInt(hex.slice(1), 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function _ptLuminance(hex) {
+    return _ptRgb(hex).map(v => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    }).reduce((acc, v, i) => acc + v * [0.2126, 0.7152, 0.0722][i], 0);
+}
+
+function _ptContrast(a, b) {
+    const l1 = _ptLuminance(a), l2 = _ptLuminance(b);
+    return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+function _ptBlend(hex, target, amount) {
+    const a = _ptRgb(hex), b = _ptRgb(target);
+    return '#' + a.map((v, i) => Math.round(v + (b[i] - v) * amount).toString(16).padStart(2, '0')).join('');
+}
+
+// Keeps the theme hue but pushes it toward black or white until it reads on the
+// surface it is painted on. Bright themes on light surfaces are the bad case.
+function _ptReadable(color, bg, minRatio) {
+    const c = ptHex(color);
+    const b = ptHex(bg);
+    if (!c || !b || !profileThemeContrastEnabled()) return c || color;
+    if (_ptContrast(c, b) >= minRatio) return c;
+
+    const target = _ptLuminance(b) > 0.22 ? '#000000' : '#ffffff';
+    for (let i = 1; i <= 20; i++) {
+        const mixed = _ptBlend(c, target, i / 20);
+        if (_ptContrast(mixed, b) >= minRatio) return mixed;
+    }
+    return target;
+}
+
+function _ptSurface(el, buttonColor) {
+    if (buttonColor) return _ptShade(buttonColor, 0.75);
+    try {
+        const hex = _ptToHex(getComputedStyle(el).getPropertyValue('--bg-card'));
+        if (hex) return hex;
+    } catch {}
+    return '#0f0f0f';
+}
+
 function profileThemeColors(user) {
     if (!profileThemeEnabled() || !user) return null;
 
@@ -68,11 +133,13 @@ function _ptPaint(el, c) {
         el.style.setProperty('--pt-bg-btn-h', c.button);
         el.style.setProperty('--pt-brd', _ptShade(_ptShade(c.button, 0.75), 1.10));
     }
+    const surface = _ptSurface(el, c.button);
     if (c.subtext) {
-        el.style.setProperty('--pt-tx2', c.subtext);
-        el.style.setProperty('--pt-tx3', c.subtext);
+        const readable = _ptReadable(c.subtext, surface, 4.5);
+        el.style.setProperty('--pt-tx2', readable);
+        el.style.setProperty('--pt-tx3', readable);
     }
-    if (c.icon) el.style.setProperty('--pt-icon', c.icon);
+    if (c.icon) el.style.setProperty('--pt-icon', _ptReadable(c.icon, surface, 3));
     el.classList.add('has-profile-theme');
     el.classList.toggle('pt-has-button', !!c.button);
     el.classList.toggle('pt-has-text', !!c.subtext);
@@ -103,6 +170,7 @@ function profileThemeStripes(theme) {
 }
 
 window.profileThemeEnabled  = profileThemeEnabled;
+window.profileThemeContrastEnabled = profileThemeContrastEnabled;
 window.profileThemeColors   = profileThemeColors;
 window.applyProfileTheme    = applyProfileTheme;
 window.profileThemeStripes  = profileThemeStripes;

--- a/frontend/core/logic/profile-theme.js
+++ b/frontend/core/logic/profile-theme.js
@@ -120,7 +120,7 @@ function profileThemeColors(user) {
 }
 
 const PT_VARS = ['--pt-accent', '--pt-accent-lt', '--pt-bg-card', '--pt-bg-hover',
-    '--pt-bg-input', '--pt-bg-btn', '--pt-bg-btn-h', '--pt-brd', '--pt-tx2', '--pt-tx3', '--pt-icon'];
+    '--pt-bg-input', '--pt-bg-btn', '--pt-bg-btn-h', '--pt-brd', '--pt-tx2', '--pt-tx3', '--pt-icon', '--pt-icon-fg'];
 
 function _ptPaint(el, c) {
     if (c.button) {
@@ -139,7 +139,11 @@ function _ptPaint(el, c) {
         el.style.setProperty('--pt-tx2', readable);
         el.style.setProperty('--pt-tx3', readable);
     }
-    if (c.icon) el.style.setProperty('--pt-icon', _ptReadable(c.icon, surface, 3));
+    if (c.icon) {
+        const iconColor = _ptReadable(c.icon, surface, 3);
+        el.style.setProperty('--pt-icon', iconColor);
+        el.style.setProperty('--pt-icon-fg', _ptLuminance(iconColor) > 0.4 ? '#111111' : '#ffffff');
+    }
     el.classList.add('has-profile-theme');
     el.classList.toggle('pt-has-button', !!c.button);
     el.classList.toggle('pt-has-text', !!c.subtext);

--- a/frontend/core/modals/auth-modal/auth-modal.html
+++ b/frontend/core/modals/auth-modal/auth-modal.html
@@ -1,8 +1,11 @@
         <div class="modal-box" style="max-width:396px;">
-            <div class="modal-icon" style="background:rgba(56,132,255,.1);color:var(--accent);"><span class="msi" style="font-size:22px;">shield</span></div>
-            <div class="modal-title" data-i18n="profiles.2fa.title">VRChat 2FA Verification</div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="profiles.2fa.title">VRChat 2FA Verification</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modal2FA').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="modal-icon" style="background:rgba(56,132,255,.1);color:var(--accent);margin-top:20px;"><span class="msi" style="font-size:22px;">shield</span></div>
             <div class="modal-msg" id="modal2FAMsg" data-i18n="profiles.2fa.default_message">Enter the 6-digit code from your email or authenticator app.</div>
             <div style="margin:16px 0;"><input type="text" id="modal2FACode" maxlength="6" placeholder="000000" autocomplete="one-time-code" style="width:100%;text-align:center;font-size:24px;letter-spacing:8px;font-weight:700;padding:12px;background:var(--bg-input);border:none;border-radius:8px;color:var(--tx0);outline:none;font-family:inherit;" onkeydown="if(event.key==='Enter')modal2FASubmit()"></div>
             <div id="modal2FAError" style="font-size:11px;color:var(--err);margin-bottom:8px;min-height:16px;"></div>
-            <div class="modal-btns"><button class="vrcn-button-round" onclick="document.getElementById('modal2FA').style.display='none'" data-i18n="common.cancel">Cancel</button><button class="vrcn-button-round vrcn-btn-join" onclick="modal2FASubmit()" data-i18n="profiles.2fa.verify">Verify</button></div>
+            <div class="modal-btns"><button class="vrcn-button-round vrcn-btn-join" onclick="modal2FASubmit()" data-i18n="profiles.2fa.verify">Verify</button></div>
         </div>

--- a/frontend/core/modals/boop-modal/boop-modal.js
+++ b/frontend/core/modals/boop-modal/boop-modal.js
@@ -118,8 +118,8 @@ function openBoopModal(userId, displayName) {
     overlay.style.display = 'flex'; // inline display required by _closeTopModal (Escape)
     overlay.innerHTML = `
         <div class="modal-box wide narrow">
-            <div class="modal-title">${esc(t('boop.title', 'Send a Boop'))}</div>
-            <div class="modal-msg" style="margin-bottom:14px;">${esc(tf('boop.target', { name: _boopContext.displayName }, `To: ${_boopContext.displayName}`))}</div>
+            ${renderModalBar(t('boop.title', 'Send a Boop'), [modalCloseAction('closeBoopModal()')])}
+            <div class="modal-msg" style="margin:20px 0 14px;">${esc(tf('boop.target', { name: _boopContext.displayName }, `To: ${_boopContext.displayName}`))}</div>
             <div class="fd-tabs">
                 <button class="fd-tab active" id="boopTabDefault" onclick="switchBoopTab('default')">${esc(t('boop.tab_default', 'Default Emojis'))}</button>
                 ${boopHasVrcPlus() ? `<button class="fd-tab" id="boopTabCustom" onclick="switchBoopTab('custom')">${esc(t('boop.tab_custom', 'Custom'))}</button>` : ''}
@@ -132,7 +132,6 @@ function openBoopModal(userId, displayName) {
                 <button class="vrcn-button" id="boopRefreshBtn" onclick="refreshBoopCustomEmojis()" title="${esc(t('common.refresh', 'Refresh'))}" style="display:none;"><span class="msi">refresh</span></button>
             </div>
             <div class="modal-btns" style="margin-top:16px;">
-                <button class="vrcn-button" onclick="closeBoopModal()">${esc(t('common.cancel', 'Cancel'))}</button>
                 <button class="vrcn-button vrcn-btn-primary" id="boopSendBtn" onclick="sendBoopFromModal()">${esc(t('boop.send', 'Send Boop'))}</button>
             </div>
         </div>`;

--- a/frontend/core/modals/create-instance-modal/create-instance-modal.js
+++ b/frontend/core/modals/create-instance-modal/create-instance-modal.js
@@ -75,6 +75,7 @@ function openCreateInstanceModal() {
     if (!el) return;
 
     el.innerHTML = `
+        ${renderModalBar(worldName, [modalCloseAction('closeCreateInstanceModal()')], { flush: true })}
         ${thumb ? `<div class="fd-banner"><img src="${esc(thumb)}" onerror="this.parentElement.style.display='none'"><div class="fd-banner-fade"></div></div>` : ''}
         <div class="fd-content${thumb ? ' fd-has-banner' : ''}" style="padding:20px 32px;">
             <h2 style="margin:0 0 16px;color:var(--tx0);font-size:18px;">${esc(worldName)}</h2>
@@ -137,7 +138,6 @@ function openCreateInstanceModal() {
                 <button class="vrcn-button-round vrcn-btn-primary" id="ciCreateJoinBtn" onclick="doCreateInstance(true)">
                     <span class="msi" style="font-size:14px;">play_circle</span> ${t('worlds.instances.create_join', 'Create &amp; Join')}
                 </button>
-                <button class="vrcn-button-round" style="margin-left:auto;" onclick="closeCreateInstanceModal()">${t('common.close', 'Close')}</button>
             </div>
         </div>`;
 

--- a/frontend/core/modals/event-modal/event-modal.js
+++ b/frontend/core/modals/event-modal/event-modal.js
@@ -82,7 +82,7 @@ function renderEventDetail(ev) {
     const evHeaderActions = renderModalActions([
         { icon: isFollowing ? 'notifications_off' : 'notifications_active', title: followLabel, onclick: `toggleFollowEvent('${groupId}','${calendarId}',${isFollowing},this)` },
         gid ? { icon: 'group', title: t('calendar.detail.open_group', 'Open Group'), onclick: `navOpenModal('group','${groupOpenId}','${jsq(groupName || '')}')` } : null,
-        { icon: 'close', title: t('common.close', 'Close'), onclick: `closeEventDetail()`, header: true },
+        { icon: 'close', title: t('common.close', 'Close'), onclick: `closeEventDetail()` },
     ]);
 
     el.innerHTML = `${evHeaderActions}

--- a/frontend/core/modals/friend-invite-modal/friend-invite-modal.js
+++ b/frontend/core/modals/friend-invite-modal/friend-invite-modal.js
@@ -30,13 +30,13 @@ function openFriendInviteModal(userId, displayName, initialTab) {
     el.style.zIndex = '10003';
     el.innerHTML = `
         <div class="modal-box inv-single-modal">
+            ${renderModalBar(_invModalDisplayName, [modalCloseAction('closeFriendInviteModal()')], { flush: true })}
             <div class="inv-world-banner" style="${thumb ? `background-image:url('${cssUrl(thumb)}')` : ''}">
                 <div class="inv-world-fade"></div>
                 <div class="inv-world-info">
                     <div style="font-size:11px;color:rgba(255,255,255,.65);margin-bottom:2px;">${inviteTitle}</div>
                     <div class="inv-world-name">${esc(worldName)}</div>
                 </div>
-                <button class="inv-close-btn" onclick="closeFriendInviteModal()"><span class="msi" style="font-size:18px;">close</span></button>
             </div>
             <div class="fd-tabs" style="margin:14px 16px 0;flex-shrink:0;">
                 <button class="fd-tab active" id="invTab_direct"  onclick="_invModalSetTab('direct')">${t('profiles.invite.tab.direct', 'Directly')}</button>

--- a/frontend/core/modals/group-modal/group-modal.js
+++ b/frontend/core/modals/group-modal/group-modal.js
@@ -1566,8 +1566,9 @@ function openGroupRolesModal(groupId) {
     overlay.style.display = 'flex';
     overlay.addEventListener('click', e => { if (e.target === overlay) closeGroupRolesModal(); });
 
+    const myRoleIds = new Set(Array.isArray(g.myRoleIds) ? g.myRoleIds : []);
     const body = roles.length
-        ? roles.map((r, i) => _buildRoleViewCard(r, i)).join('')
+        ? roles.map((r, i) => _buildRoleViewCard(r, i, myRoleIds.has(r.id))).join('')
         : `<div class="myp-empty">${t('groups.roles.empty', 'No roles found')}</div>`;
 
     overlay.innerHTML = `<div class="gp-modal" style="width:460px;max-width:92vw;max-height:80vh;display:flex;flex-direction:column;">
@@ -1581,9 +1582,10 @@ function closeGroupRolesModal() {
     document.getElementById('groupRolesOverlay')?.remove();
 }
 
-function _buildRoleViewCard(role, idx) {
+function _buildRoleViewCard(role, idx, isMine) {
     const rid   = 'grv' + idx;
-    const badge = role.isManagementRole ? `<span class="vrcn-badge" style="margin-right:6px;">${t('groups.roles.system', 'System')}</span>` : '';
+    const badge = (isMine ? `<span class="vrcn-badge ok" style="margin-right:6px;">${t('groups.roles.yours', 'Your role')}</span>` : '')
+        + (role.isManagementRole ? `<span class="vrcn-badge" style="margin-right:6px;">${t('groups.roles.system', 'System')}</span>` : '');
     const perms = role.permissions || [];
     const known = new Set(ROLE_PERM_DEFS.map(p => p.key));
 

--- a/frontend/core/modals/group-modal/group-modal.js
+++ b/frontend/core/modals/group-modal/group-modal.js
@@ -1567,8 +1567,9 @@ function openGroupRolesModal(groupId) {
     overlay.addEventListener('click', e => { if (e.target === overlay) closeGroupRolesModal(); });
 
     const myRoleIds = new Set(Array.isArray(g.myRoleIds) ? g.myRoleIds : []);
+    const gid = g.id || groupId || '';
     const body = roles.length
-        ? roles.map((r, i) => _buildRoleViewCard(r, i, myRoleIds.has(r.id))).join('')
+        ? roles.map((r, i) => _buildRoleViewCard(r, i, myRoleIds.has(r.id), gid)).join('')
         : `<div class="myp-empty">${t('groups.roles.empty', 'No roles found')}</div>`;
 
     overlay.innerHTML = `<div class="gp-modal" style="width:460px;max-width:92vw;max-height:80vh;display:flex;flex-direction:column;">
@@ -1582,7 +1583,7 @@ function closeGroupRolesModal() {
     document.getElementById('groupRolesOverlay')?.remove();
 }
 
-function _buildRoleViewCard(role, idx, isMine) {
+function _buildRoleViewCard(role, idx, isMine, groupId) {
     const rid   = 'grv' + idx;
     const badge = (isMine ? `<span class="vrcn-badge ok" style="margin-right:6px;">${t('groups.roles.yours', 'Your role')}</span>` : '')
         + (role.isManagementRole ? `<span class="vrcn-badge" style="margin-right:6px;">${t('groups.roles.system', 'System')}</span>` : '');
@@ -1605,7 +1606,7 @@ function _buildRoleViewCard(role, idx, isMine) {
     }
 
     return `<div class="gd-role-card" id="gdrole-${rid}">
-        <div class="gd-role-header" onclick="toggleGdRoleExpand('${rid}')">
+        <div class="gd-role-header" onclick="toggleGroupRoleView('${rid}','${jsq(role.id || '')}','${jsq(groupId || '')}')">
             <div style="flex:1;min-width:0;">
                 <div class="gd-role-name">${badge}${esc(role.name || '')}</div>
                 <div class="gd-role-meta">${esc(getRoleMetaText(role))}</div>
@@ -1618,8 +1619,20 @@ function _buildRoleViewCard(role, idx, isMine) {
                 <div class="gd-role-section-title">${t('groups.roles.permissions', 'Permissions')}</div>
                 ${permsHtml}
             </div>
+            <div class="gd-role-section">
+                <div class="gd-role-section-title">${t('groups.roles.tabs.members', 'Members')}</div>
+                <div id="grv-members-${esc(role.id || '')}"><div style="padding:8px 0;font-size:12px;color:var(--tx3);">${t('common.loading', 'Loading...')}</div></div>
+            </div>
         </div>
     </div>`;
+}
+
+function toggleGroupRoleView(rid, roleId, groupId) {
+    toggleGdRoleExpand(rid);
+    const list = document.getElementById('grv-members-' + roleId);
+    if (!list || list.dataset.loaded || !groupId || !roleId) return;
+    list.dataset.loaded = '1';
+    sendToCS({ action: 'vrcGetGroupRoleMembers', groupId, roleId });
 }
 
 function getRolePermissionDescription(def) {
@@ -1770,13 +1783,15 @@ function switchGdRoleTab(roleId, tab, btn) {
 }
 
 function onGroupRoleMembers(data) {
-    const listEl = document.getElementById('gdrole-members-list-' + data.roleId);
-    if (!listEl) return;
-    if (!data.members || data.members.length === 0) {
-        listEl.innerHTML = renderGroupEmptyMessage('groups.roles.no_members', 'No members with this role.');
-        return;
-    }
-    listEl.innerHTML = data.members.map(m => renderGroupMemberCard(m)).join('');
+    const targets = [
+        document.getElementById('gdrole-members-list-' + data.roleId),
+        document.getElementById('grv-members-' + data.roleId),
+    ].filter(Boolean);
+    if (!targets.length) return;
+    const html = (!data.members || data.members.length === 0)
+        ? renderGroupEmptyMessage('groups.roles.no_members', 'No members with this role.')
+        : data.members.map(m => renderGroupMemberCard(m)).join('');
+    targets.forEach(el => { el.innerHTML = html; });
 }
 
 function openCreateRoleForm() {

--- a/frontend/core/modals/group-modal/group-modal.js
+++ b/frontend/core/modals/group-modal/group-modal.js
@@ -70,6 +70,22 @@ function confirmLeaveGroup(groupId, groupName) {
     document.body.appendChild(o);
 }
 
+function _gdMoreDropdown(g, gidJs) {
+    const items = [];
+    if (g.isJoined) {
+        items.push({ icon: 'shield_person', label: t('context_menu.group.represent', 'Represent this group'), onclick: `sendToCS({action:'vrcRepresentGroup',groupId:'${gidJs}'})`, disabled: g.isRepresenting === true });
+        items.push({ icon: 'visibility', label: t('context_menu.group.visibility', 'Visibility'), submenu: [
+            { icon: 'public',         label: t('groups.visibility.visible', 'Visible for Everyone'), active: (g.visibility || 'visible') === 'visible', onclick: `setGroupVisibility('${gidJs}','visible')` },
+            { icon: 'people',         label: t('groups.visibility.friends', 'Visible for Friends'),  active: (g.visibility || 'visible') === 'friends', onclick: `setGroupVisibility('${gidJs}','friends')` },
+            { icon: 'visibility_off', label: t('groups.visibility.hidden',  'Visible for None'),     active: (g.visibility || 'visible') === 'hidden',  onclick: `setGroupVisibility('${gidJs}','hidden')` },
+        ] });
+    }
+    if ((g.roles || []).length) {
+        items.push({ icon: 'shield', label: t('groups.roles.show', 'Show Roles'), onclick: `openGroupRolesModal('${gidJs}')` });
+    }
+    return items.length ? { label: t('common.more', 'More'), dropdown: items } : null;
+}
+
 function renderGroupDetail(g) {
     const _gdPrevBtn = document.querySelector('#detailModalContent .fd-tab.active[onclick^="switchGdTab("]');
     const _gdPrevTab = _gdPrevBtn ? ((/switchGdTab\('([^']+)'/.exec(_gdPrevBtn.getAttribute('onclick') || '') || [])[1] || '') : '';
@@ -118,14 +134,7 @@ function renderGroupDetail(g) {
         (g.isJoined && canInvite) ? { icon: 'person_add', title: t('groups.actions.invite', 'Invite'), onclick: `openGroupInviteModal('${gidJs}')` } : null,
         (g.isJoined && canPost)   ? { icon: 'post_add',   title: t('groups.actions.post', 'Post'),     onclick: `openGroupPostModal('${gidJs}')` } : null,
         (g.isJoined && canEvent)  ? { icon: 'event',      title: t('groups.actions.events', 'Events'), onclick: `openGroupEventModal('${gidJs}')` } : null,
-        g.isJoined ? { label: t('common.more', 'More'), dropdown: [
-            { icon: 'shield_person', label: t('context_menu.group.represent', 'Represent this group'), onclick: `sendToCS({action:'vrcRepresentGroup',groupId:'${gidJs}'})`, disabled: g.isRepresenting === true },
-            { icon: 'visibility', label: t('context_menu.group.visibility', 'Visibility'), submenu: [
-                { icon: 'public',         label: t('groups.visibility.visible', 'Visible for Everyone'), active: (g.visibility || 'visible') === 'visible', onclick: `setGroupVisibility('${gidJs}','visible')` },
-                { icon: 'people',         label: t('groups.visibility.friends', 'Visible for Friends'),  active: (g.visibility || 'visible') === 'friends', onclick: `setGroupVisibility('${gidJs}','friends')` },
-                { icon: 'visibility_off', label: t('groups.visibility.hidden',  'Visible for None'),     active: (g.visibility || 'visible') === 'hidden',  onclick: `setGroupVisibility('${gidJs}','hidden')` },
-            ] },
-        ] } : null,
+        _gdMoreDropdown(g, gidJs),
         { icon: 'refresh', iconClass: 'fd-refresh-spin', title: t('common.refresh', 'Refresh'), onclick: `triggerModalRefresh({action:'vrcGetGroup',groupId:'${gidJs}',force:true})` },
         { icon: 'link_2', title: t('common.share', 'Share'), onclick: `navigator.clipboard.writeText('https://vrchat.com/home/group/${esc(g.id)}').then(()=>showToast(true,t('common.link_copied','Link copied!')))` },
         { icon: 'close', title: t('common.close', 'Close'), onclick: `closeGroupDetail()` },
@@ -1540,6 +1549,75 @@ const ROLE_PERM_DEFS = [
 
 function getRolePermissionLabel(def) {
     return t(`groups.roles.permissions.${def.key}.label`, def.label);
+}
+
+function openGroupRolesModal(groupId) {
+    const g = (_groupDetailCache && _groupDetailCache[groupId])
+        || window._currentGroupDetailFull
+        || window._currentGroupDetail
+        || {};
+    const roles = Array.isArray(g.roles) ? g.roles : [];
+
+    document.getElementById('groupRolesOverlay')?.remove();
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.id = 'groupRolesOverlay';
+    overlay.style.zIndex = '10004';
+    overlay.style.display = 'flex';
+    overlay.addEventListener('click', e => { if (e.target === overlay) closeGroupRolesModal(); });
+
+    const body = roles.length
+        ? roles.map((r, i) => _buildRoleViewCard(r, i)).join('')
+        : `<div class="myp-empty">${t('groups.roles.empty', 'No roles found')}</div>`;
+
+    overlay.innerHTML = `<div class="gp-modal" style="width:460px;max-width:92vw;max-height:80vh;display:flex;flex-direction:column;">
+        ${renderModalBar(t('groups.tabs.roles', 'Roles'), [modalCloseAction('closeGroupRolesModal()')])}
+        <div class="gp-modal-body" style="flex:1;overflow-y:auto;">${body}</div>
+    </div>`;
+    document.body.appendChild(overlay);
+}
+
+function closeGroupRolesModal() {
+    document.getElementById('groupRolesOverlay')?.remove();
+}
+
+function _buildRoleViewCard(role, idx) {
+    const rid   = 'grv' + idx;
+    const badge = role.isManagementRole ? `<span class="vrcn-badge" style="margin-right:6px;">${t('groups.roles.system', 'System')}</span>` : '';
+    const perms = role.permissions || [];
+    const known = new Set(ROLE_PERM_DEFS.map(p => p.key));
+
+    let permsHtml;
+    if (perms.includes('*')) {
+        permsHtml = `<div style="padding:8px 0;font-size:12px;color:var(--tx2);">${t('groups.roles.full_access', 'This role has full access (all permissions).')}</div>`;
+    } else if (!perms.length) {
+        permsHtml = `<div style="padding:8px 0;font-size:12px;color:var(--tx3);">${t('groups.roles.no_permissions', 'This role has no permissions.')}</div>`;
+    } else {
+        const rows = ROLE_PERM_DEFS.filter(p => perms.includes(p.key)).map(p =>
+            `<div class="gd-perm-row"><div class="gd-perm-info"><div class="gd-perm-label">${esc(getRolePermissionLabel(p))}</div><div class="gd-perm-desc">${esc(getRolePermissionDescription(p))}</div></div></div>`
+        );
+        perms.filter(k => !known.has(k)).forEach(k =>
+            rows.push(`<div class="gd-perm-row"><div class="gd-perm-info"><div class="gd-perm-label">${esc(k)}</div></div></div>`)
+        );
+        permsHtml = rows.join('');
+    }
+
+    return `<div class="gd-role-card" id="gdrole-${rid}">
+        <div class="gd-role-header" onclick="toggleGdRoleExpand('${rid}')">
+            <div style="flex:1;min-width:0;">
+                <div class="gd-role-name">${badge}${esc(role.name || '')}</div>
+                <div class="gd-role-meta">${esc(getRoleMetaText(role))}</div>
+            </div>
+            <span class="msi gd-role-chevron" style="font-size:18px;color:var(--tx3);transition:transform .2s;">expand_more</span>
+        </div>
+        <div class="gd-role-body" id="gdrole-body-${rid}" style="display:none;">
+            ${role.description ? `<div class="gd-role-section"><div class="gd-role-section-title">${t('groups.sections.description', 'Description')}</div><div style="font-size:12px;color:var(--tx2);white-space:pre-wrap;">${esc(role.description)}</div></div>` : ''}
+            <div class="gd-role-section">
+                <div class="gd-role-section-title">${t('groups.roles.permissions', 'Permissions')}</div>
+                ${permsHtml}
+            </div>
+        </div>
+    </div>`;
 }
 
 function getRolePermissionDescription(def) {

--- a/frontend/core/modals/group-modal/group-modal.js
+++ b/frontend/core/modals/group-modal/group-modal.js
@@ -60,11 +60,11 @@ function confirmLeaveGroup(groupId, groupName) {
     o.id = 'leaveGroupModal';
     o.style.zIndex = '10003';
     o.onclick = e => { if (e.target === o) o.remove(); };
-    o.innerHTML = `<div class="modal-box"><div class="modal-icon danger"><span class="msi" style="font-size:22px;">logout</span></div>
-        <div class="modal-title">${t('groups.leave_confirm.title', 'Leave Group')}</div>
+    o.innerHTML = `<div class="modal-box">
+        ${renderModalBar(t('groups.leave_confirm.title', 'Leave Group'), [modalCloseAction("document.getElementById('leaveGroupModal').remove()")])}
+        <div class="modal-icon danger" style="margin-top:20px;"><span class="msi" style="font-size:22px;">logout</span></div>
         <div class="modal-msg">${tf('groups.leave_confirm.message', { name: esc(groupName || '') }, 'Leave {name}?')}</div>
         <div class="modal-btns">
-            <button class="vrcn-button-round" onclick="document.getElementById('leaveGroupModal').remove()">${t('common.cancel', 'Cancel')}</button>
             <button class="vrcn-button-round vrcn-btn-danger" onclick="document.getElementById('leaveGroupModal').remove();sendToCS({action:'vrcLeaveGroup',groupId:'${jsq(groupId)}'});closeGroupDetail();">${t('groups.actions.leave_group', 'Leave Group')}</button>
         </div></div>`;
     document.body.appendChild(o);
@@ -926,10 +926,7 @@ function openGroupPostModal(groupId, editPost = null) {
     }
     overlay.innerHTML = `
     <div class="gp-modal" role="dialog" aria-label="${esc(modalAriaLabel)}">
-        <div class="gp-modal-header">
-            <span class="msi" style="font-size:20px;color:var(--accent);">edit</span>
-            <span>${esc(modalTitle)}</span>
-        </div>
+        ${renderModalBar(modalTitle, [modalCloseAction('closeGroupPostModal()')])}
         <div class="gp-modal-body">
             <label class="gp-label">${t('groups.posts.fields.title', 'Title')}</label>
             <input id="gpTitle" class="vrcn-edit-field" type="text" placeholder="${esc(t('groups.posts.fields.title_placeholder', 'Post title...'))}" maxlength="200" style="width:100%;">
@@ -957,7 +954,6 @@ function openGroupPostModal(groupId, editPost = null) {
         </div>
         <div class="gp-modal-footer">
             <button class="vrcn-button-round vrcn-btn-join" id="gpSubmitBtn" onclick="submitGroupPost()"><span class="msi" style="font-size:16px;vertical-align:middle;margin-right:4px;">send</span>${esc(submitLabel)}</button>
-            <button class="vrcn-button-round" onclick="closeGroupPostModal()" style="margin-left:auto;">${t('common.cancel', 'Cancel')}</button>
         </div>
     </div>`;
     initAllVnSelects();
@@ -1351,10 +1347,7 @@ function openGroupEventModal(groupId) {
     }
     overlay.innerHTML = `
     <div class="gp-modal" role="dialog" aria-label="${esc(t('groups.events.modal.aria_label', 'Create Group Event'))}" style="max-height:calc(100vh - var(--tb-h) - 32px);overflow-y:auto;">
-        <div class="gp-modal-header">
-            <span class="msi" style="font-size:20px;color:var(--accent);">event</span>
-            <span>${t('groups.events.modal.title', 'Create Group Event')}</span>
-        </div>
+        ${renderModalBar(t('groups.events.modal.title', 'Create Group Event'), [modalCloseAction('closeGroupEventModal()')])}
         <div class="gp-modal-body">
             <label class="gp-label">${t('groups.events.fields.name', 'Event Name')}</label>
             <input id="gevName" class="vrcn-edit-field" type="text" placeholder="${esc(t('groups.events.fields.name_placeholder', 'Event name...'))}" maxlength="64" style="width:100%;">
@@ -1418,7 +1411,6 @@ function openGroupEventModal(groupId) {
         </div>
         <div class="gp-modal-footer">
             <button class="vrcn-button-round vrcn-btn-join" id="gevSubmitBtn" onclick="submitGroupEvent()"><span class="msi" style="font-size:16px;vertical-align:middle;margin-right:4px;">event</span>${t('groups.events.submit', 'Create Event')}</button>
-            <button class="vrcn-button-round" onclick="closeGroupEventModal()" style="margin-left:auto;">${t('common.cancel', 'Cancel')}</button>
         </div>
     </div>`;
     initAllVnSelects();
@@ -1987,13 +1979,13 @@ function _renderGroupInviteBox() {
     const bannerUrl = gd.bannerUrl || '';
     const bannerBg = bannerUrl || groupIcon;
     box.innerHTML = `
+        ${renderModalBar(groupName, [modalCloseAction('closeInviteModal();_grpInvGroupId=null;')], { flush: true })}
         <div class="inv-world-banner" style="background-image:url('${esc(bannerBg)}')">
             <div class="inv-world-fade"></div>
             <div class="inv-world-info">
                 <div class="inv-world-name">${esc(groupName)}</div>
                 <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:3px;">${esc(t('groups.invite.subtitle', 'Invite to this group'))}</div>
             </div>
-            <button class="inv-close-btn" onclick="closeInviteModal();_grpInvGroupId=null;" title="${esc(t('common.close', 'Close'))}"><span class="msi">close</span></button>
         </div>
         <div class="inv-search-wrap">
             <span class="msi inv-search-icon">search</span>

--- a/frontend/core/modals/image-picker-modal/image-picker-modal.js
+++ b/frontend/core/modals/image-picker-modal/image-picker-modal.js
@@ -20,18 +20,13 @@ function openImagePicker(type, targetId) {
     overlay.style.cssText = 'position:fixed;inset:0;z-index:10003;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center;animation:fadeIn .12s ease;backdrop-filter:blur(4px);';
     overlay.innerHTML = `
         <div class="gp-modal" style="width:460px;max-height:80vh;display:flex;flex-direction:column;">
-            <div class="gp-modal-header">
-                <span class="msi" style="font-size:20px;color:var(--accent);">edit</span>
-                <span id="imagePickerTitle">${esc(title)}</span>
-                <button class="vrcn-button-round" onclick="closeImagePicker()" title="${esc(t('common.close', 'Close'))}"><span class="msi" style="font-size:18px;">close</span></button>
-            </div>
+            ${renderModalBar(title, [modalCloseAction('closeImagePicker()')], { titleId: 'imagePickerTitle' })}
             <div class="gp-modal-body" style="flex:1;overflow-y:auto;">
                 <div id="imagePickerGrid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(80px,1fr));gap:6px;padding:4px 0;">
                     <div style="grid-column:1/-1;text-align:center;padding:20px;font-size:11px;color:var(--tx3);">${t('common.loading', 'Loading...')}</div>
                 </div>
             </div>
             <div class="gp-modal-footer">
-                <button class="vrcn-button-round" onclick="closeImagePicker()">${t('common.cancel', 'Cancel')}</button>
                 <button class="vrcn-button-round vrcn-btn-join" id="imagePickerApply" disabled onclick="applyImagePicker()" style="opacity:.45;">
                     <span class="msi" style="font-size:16px;vertical-align:middle;margin-right:4px;">check</span>${t('common.apply', 'Apply')}
                 </button>
@@ -86,13 +81,12 @@ function refreshImagePickerTranslations() {
     if (!overlay || !_pickerContext) return;
     const isIcon = _pickerContext.type.endsWith('-icon');
     const titleEl = document.getElementById('imagePickerTitle');
-    if (titleEl) titleEl.textContent = isIcon
+    const newTitle = isIcon
         ? t('profiles.picker.select_icon', 'Select Icon')
         : t('profiles.picker.select_banner', 'Select Banner Photo');
-    const closeBtn = overlay.querySelector('.gp-modal-header .vrcn-button-round');
+    if (titleEl) { titleEl.textContent = newTitle; titleEl.title = newTitle; }
+    const closeBtn = overlay.querySelector('.fd-modal-bar-actions .fd-action-btn');
     if (closeBtn) closeBtn.title = t('common.close', 'Close');
-    const cancelBtn = overlay.querySelector('.gp-modal-footer .vrcn-button-round');
-    if (cancelBtn) cancelBtn.textContent = t('common.cancel', 'Cancel');
     const applyBtn = document.getElementById('imagePickerApply');
     if (applyBtn) applyBtn.innerHTML = `<span class="msi" style="font-size:16px;vertical-align:middle;margin-right:4px;">check</span>${t('common.apply', 'Apply')}`;
     const grid = document.getElementById('imagePickerGrid');

--- a/frontend/core/modals/instance-modal/instance-modal.js
+++ b/frontend/core/modals/instance-modal/instance-modal.js
@@ -153,7 +153,7 @@ function openInstanceInfoModal() {
     const prevIimScroller = c.querySelector('.iim-scroll');
     const prevIimScrollTop = prevIimScroller?.scrollTop || 0;
     const prevIimScrollLeft = prevIimScroller?.scrollLeft || 0;
-    c.innerHTML = `${bannerHtml}
+    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}${bannerHtml}
     <div class="fd-content${thumb ? ' fd-has-banner' : ''}" style="padding:16px;">
         <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(name)}</h2>
         <div class="fd-badges-row">
@@ -167,7 +167,6 @@ function openInstanceInfoModal() {
         <div class="fd-actions">
             <button class="vrcn-button-round" onclick="closeInstanceInfoModal();openInviteModal()"><span class="msi">person_add</span> ${t('instance.actions.invite', 'Invite')}</button>
             <button class="vrcn-button-round" onclick="closeInstanceInfoModal();openWorldSearchDetail('${wid}')">${t('dashboard.instances.open_world', 'Open World')}</button>
-            <button class="vrcn-button-round" style="margin-left:auto;" onclick="closeInstanceInfoModal()">${t('common.close', 'Close')}</button>
         </div>
     </div>`;
 

--- a/frontend/core/modals/invite-modal/invite-modal.js
+++ b/frontend/core/modals/invite-modal/invite-modal.js
@@ -63,6 +63,7 @@ function _renderInviteModal() {
     const ageGateBadge = ageGate
         ? `<span class="vrcn-badge" style="background:rgba(255,75,85,.15);color:var(--err);">${esc(t('worlds.instances.age_gated', 'Age Gated'))}</span>` : '';
     box.innerHTML = `
+        ${renderModalBar(worldName, [modalCloseAction('closeInviteModal()')], { flush: true })}
         <div class="inv-world-banner" style="background-image:url('${esc(worldThumb)}')">
             <div class="inv-world-fade"></div>
             <div class="inv-world-info">
@@ -70,7 +71,6 @@ function _renderInviteModal() {
                 <div class="inv-world-name">${esc(worldName)}</div>
                 <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:3px;">${esc(t('invite.multi.subtitle', 'Invite to this instance'))}</div>
             </div>
-            <button class="inv-close-btn" onclick="closeInviteModal()" title="${esc(t('common.close', 'Close'))}"><span class="msi">close</span></button>
         </div>
         <div class="inv-search-wrap">
             <span class="msi inv-search-icon">search</span>

--- a/frontend/core/modals/modal-nav.js
+++ b/frontend/core/modals/modal-nav.js
@@ -259,6 +259,9 @@ function _navDoOpen(type, id, id2) {
         case 'instance':    if (typeof _reopenCachedInstance === 'function') _reopenCachedInstance(id); break;
         case 'myprofile':   if (typeof openMyProfileModal === 'function') openMyProfileModal(); break;
         case 'photo':       if (typeof openPhotoDetail === 'function') openPhotoDetail(id); break;
+        case 'tlEvent':     if (typeof openTlDetail === 'function') openTlDetail(id); break;
+        case 'ftEvent':     if (typeof openFtDetail === 'function') openFtDetail(id); break;
+        case 'ftGps':       if (typeof openFtGpsDetail === 'function') openFtGpsDetail(id); break;
     }
 }
 
@@ -273,6 +276,9 @@ function _navOverlayIdForType(type) {
         case 'instance':    return 'modalMyInstance';
         case 'myprofile':   return 'modalMyProfile';
         case 'photo':       return 'photoDetailModal';
+        case 'tlEvent':     return 'modalDetail';
+        case 'ftEvent':     return 'modalDetail';
+        case 'ftGps':       return 'modalFtGpsDetail';
         default:            return null;
     }
 }
@@ -453,6 +459,13 @@ function _navCloseForEntry(entry) {
         case 'photo':
             if (typeof closePhotoDetail === 'function') closePhotoDetail(true);
             break;
+        case 'tlEvent':
+        case 'ftEvent':
+            if (typeof closeTlDetail === 'function') closeTlDetail(true);
+            break;
+        case 'ftGps':
+            if (typeof closeFtGpsDetail === 'function') closeFtGpsDetail(true);
+            break;
     }
 }
 
@@ -494,6 +507,9 @@ function _navTypeLabel(type) {
         instance:    typeof t === 'function' ? t('nav.modal.instance',    'Instance'): 'Instance',
         myprofile:   typeof t === 'function' ? t('nav.modal.friend',      'Profile') : 'Profile',
         photo:       typeof t === 'function' ? t('timeline.photo',        'Photo')   : 'Photo',
+        tlEvent:     typeof t === 'function' ? t('nav.timeline',          'Timeline'): 'Timeline',
+        ftEvent:     typeof t === 'function' ? t('nav.timeline',          'Timeline'): 'Timeline',
+        ftGps:       typeof t === 'function' ? t('nav.modal.instance',    'Instance'): 'Instance',
     };
     return labels[type] || type;
 }

--- a/frontend/core/modals/modal-nav.js
+++ b/frontend/core/modals/modal-nav.js
@@ -41,6 +41,18 @@ function renderModalActions(actions) {
     return header.length ? `<div class="fd-modal-actions">${_mnActionsHtml(header, false)}</div>` : '';
 }
 
+function renderModalBar(title, actions, opts) {
+    opts = opts || {};
+    const label = String(title == null ? '' : title);
+    const cls   = 'fd-modal-bar' + (opts.flush ? ' fd-modal-bar-flush' : '');
+    const idAttr = opts.titleId ? ` id="${_esc(opts.titleId)}"` : '';
+    return `<div class="${cls}"><div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title"${idAttr} title="${_esc(label)}">${_esc(label)}</span></div><div class="fd-modal-bar-actions">${opts.extra || ''}${_mnActionsHtml(actions, false)}</div></div>`;
+}
+
+function modalCloseAction(onclick) {
+    return { icon: 'close', title: typeof t === 'function' ? t('common.close', 'Close') : 'Close', onclick };
+}
+
 function refreshModalActions(actions) {
     actions = (actions || []).filter(Boolean);
     _mnActions = actions;

--- a/frontend/core/modals/modal-nav.js
+++ b/frontend/core/modals/modal-nav.js
@@ -258,6 +258,7 @@ function _navDoOpen(type, id, id2) {
         case 'event':       openEventDetail(id, id2);       break;
         case 'instance':    if (typeof _reopenCachedInstance === 'function') _reopenCachedInstance(id); break;
         case 'myprofile':   if (typeof openMyProfileModal === 'function') openMyProfileModal(); break;
+        case 'photo':       if (typeof openPhotoDetail === 'function') openPhotoDetail(id); break;
     }
 }
 
@@ -271,6 +272,7 @@ function _navOverlayIdForType(type) {
         case 'event':       return 'modalDetail';
         case 'instance':    return 'modalMyInstance';
         case 'myprofile':   return 'modalMyProfile';
+        case 'photo':       return 'photoDetailModal';
         default:            return null;
     }
 }
@@ -448,6 +450,9 @@ function _navCloseForEntry(entry) {
             if (mp) mp.style.display = 'none';
             break;
         }
+        case 'photo':
+            if (typeof closePhotoDetail === 'function') closePhotoDetail(true);
+            break;
     }
 }
 
@@ -488,6 +493,7 @@ function _navTypeLabel(type) {
         event:       typeof t === 'function' ? t('nav.modal.event',       'Event')   : 'Event',
         instance:    typeof t === 'function' ? t('nav.modal.instance',    'Instance'): 'Instance',
         myprofile:   typeof t === 'function' ? t('nav.modal.friend',      'Profile') : 'Profile',
+        photo:       typeof t === 'function' ? t('timeline.photo',        'Photo')   : 'Photo',
     };
     return labels[type] || type;
 }

--- a/frontend/core/modals/modals.css
+++ b/frontend/core/modals/modals.css
@@ -101,6 +101,25 @@ html.modal-refreshing .fd-refresh-spin { animation: modal-refresh-spin 0.8s line
     justify-content: flex-end;
 }
 
+/* === Shared Modal Title Bar === */
+
+.fd-modal-bar-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--tx0);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+.fd-modal-bar.fd-modal-bar-flush { margin: 0; }
+.fd-modal-bar.fd-modal-bar-flush + .fd-banner { margin-left: 0; margin-right: 0; }
+
+.gp-modal > .fd-modal-bar { margin: 0; border-radius: 16px 16px 0 0; flex-shrink: 0; }
+
+.fd-modal-bar + .inv-world-banner { border-radius: 0; }
+
 /* === Shared Navigation Backdrop === */
 
 #modalNavBackdrop {

--- a/frontend/core/modals/modals.css
+++ b/frontend/core/modals/modals.css
@@ -144,7 +144,8 @@ html.modal-refreshing .fd-refresh-spin { animation: modal-refresh-spin 0.8s line
 .modal-nav-active #modalWorldDetail,
 .modal-nav-active #modalDetail,
 .modal-nav-active #modalAvatarDetail,
-.modal-nav-active #modalMyInstance {
+.modal-nav-active #modalMyInstance,
+.modal-nav-active #photoDetailModal {
     background: transparent !important;
     backdrop-filter: none !important;
     animation: none !important;

--- a/frontend/core/modals/modals.css
+++ b/frontend/core/modals/modals.css
@@ -1,5 +1,9 @@
 /* === Core Modal Base Shell === */
 
+:root {
+    --fd-compact-h: min(calc((100vh - var(--tb-h) - 16px) * 0.95), 669px);
+}
+
 @keyframes modal-refresh-spin { to { transform: rotate(360deg); } }
 html.modal-refreshing .fd-refresh-spin { animation: modal-refresh-spin 0.8s linear infinite; }
 

--- a/frontend/core/modals/modals.css
+++ b/frontend/core/modals/modals.css
@@ -113,10 +113,12 @@ html.modal-refreshing .fd-refresh-spin { animation: modal-refresh-spin 0.8s line
     min-width: 0;
 }
 
+.fd-modal-bar { flex-shrink: 0; }
+
 .fd-modal-bar.fd-modal-bar-flush { margin: 0; }
 .fd-modal-bar.fd-modal-bar-flush + .fd-banner { margin-left: 0; margin-right: 0; }
 
-.gp-modal > .fd-modal-bar { margin: 0; border-radius: 16px 16px 0 0; flex-shrink: 0; }
+.gp-modal > .fd-modal-bar { margin: 0; border-radius: 16px 16px 0 0; }
 
 .fd-modal-bar + .inv-world-banner { border-radius: 0; }
 

--- a/frontend/core/modals/my-instance-modal/my-instance-modal.js
+++ b/frontend/core/modals/my-instance-modal/my-instance-modal.js
@@ -264,7 +264,9 @@ function setInstanceModal(inst) {
 
     _miModalWorldId = worldId;
 
-    const miBar = (typeof renderModalActions === 'function') ? renderModalActions([]) : '';
+    const miBar = (typeof renderModalActions === 'function')
+        ? renderModalActions([{ icon: 'close', title: t('common.close', 'Close'), onclick: 'closeMyInstanceDetail()' }])
+        : '';
 
     const instanceGroups = {}; // locBase → { friends, instanceType, instId, location }
 
@@ -330,7 +332,6 @@ function setInstanceModal(inst) {
             </div>
             <div class="mi-left-actions">
                 <button class="vrcn-button-round mi-action-btn" onclick="navOpenModal('worldSearch','${jsq(worldId)}','')">${t('dashboard.instances.open_world', 'Open World')}</button>
-                <button class="vrcn-button-round mi-action-btn" onclick="closeMyInstanceDetail()">${t('common.close', 'Close')}</button>
             </div>
         </div>
         <div class="mi-right"><div class="mi-right-scroll"><div class="mi-instance-list">${rightHtml}</div></div></div>
@@ -357,7 +358,9 @@ function setOwnInstanceModal(inst) {
 
     _miModalWorldId = worldId;
 
-    const miBar = (typeof renderModalActions === 'function') ? renderModalActions([]) : '';
+    const miBar = (typeof renderModalActions === 'function')
+        ? renderModalActions([{ icon: 'close', title: t('common.close', 'Close'), onclick: 'closeMyInstanceDetail()' }])
+        : '';
 
     const locBase = (inst.location || '').split('~')[0];
     const instId  = locBase.includes(':') ? locBase.split(':')[1] : '';
@@ -405,7 +408,6 @@ function setOwnInstanceModal(inst) {
             </div>
             <div class="mi-left-actions">
                 <button class="vrcn-button-round mi-action-btn" onclick="navOpenModal('worldSearch','${jsq(worldId)}','')">${t('dashboard.instances.open_world', 'Open World')}</button>
-                <button class="vrcn-button-round mi-action-btn" onclick="closeMyInstanceDetail()">${t('common.close', 'Close')}</button>
             </div>
         </div>
         <div class="mi-right"><div class="mi-right-scroll"><div class="mi-instance-list">${_buildInstanceCard(locBase, groupData, true)}</div></div></div>

--- a/frontend/core/modals/my-profile-modal/my-profile-modal.js
+++ b/frontend/core/modals/my-profile-modal/my-profile-modal.js
@@ -429,8 +429,8 @@ function renderMyProfileContent() {
 
     const contentHtml = `
         <div class="fd-content-pills">
-            <button class="fd-tab myp-content-pill active" id="mypWorldsPill" onclick="switchMypContentPill('worlds',this)">${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">0</span></button>
-            <button class="fd-tab myp-content-pill" id="mypAvatarsPill" onclick="switchMypContentPill('avatars',this)">${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">0</span></button>
+            <button class="fd-tab myp-content-pill active" id="mypWorldsPill" onclick="switchMypContentPill('worlds',this)">${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge fd-tab-badge">0</span></button>
+            <button class="fd-tab myp-content-pill" id="mypAvatarsPill" onclick="switchMypContentPill('avatars',this)">${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge fd-tab-badge">0</span></button>
         </div>
         <div id="mypContentWorlds">
             <div id="mypWorldsGrid"><div class="empty-msg">${t('profiles.insights.loading', 'Loading...')}</div></div>
@@ -441,7 +441,7 @@ function renderMyProfileContent() {
             <div id="mypAvatarsPageBar" class="mini-paginator"></div>
         </div>`;
 
-    const _tabBadge = (n) => `<span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${n}</span>`;
+    const _tabBadge = (n) => `<span class="vrcn-badge fd-tab-badge">${n}</span>`;
     const _mypGroupCount = (typeof myGroups !== 'undefined' && Array.isArray(myGroups)) ? myGroups.length : 0;
     const tabsHtml = `<div class="fd-tabs"${useCompact ? '' : ' style="margin-bottom:14px;"'}>
         <button class="fd-tab active" data-myptab="info" onclick="switchMypTab('info',this)">${t('profiles.tabs.info', 'Info')}</button>
@@ -796,11 +796,11 @@ function mypOwnGroupsGoPage(page) {
 
 function _mypUpdateContentCounts() {
     const wp = document.getElementById('mypWorldsPill');
-    if (wp) wp.innerHTML = `${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${_mypAllWorlds.length}</span>`;
+    if (wp) wp.innerHTML = `${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge fd-tab-badge">${_mypAllWorlds.length}</span>`;
     const ap = document.getElementById('mypAvatarsPill');
-    if (ap) ap.innerHTML = `${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${_mypAllAvatars.length}</span>`;
+    if (ap) ap.innerHTML = `${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge fd-tab-badge">${_mypAllAvatars.length}</span>`;
     const tab = document.getElementById('mypTabContentBtn');
-    if (tab) tab.innerHTML = `${t('profiles.tabs.content_label', 'Content')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${_mypAllWorlds.length + _mypAllAvatars.length}</span>`;
+    if (tab) tab.innerHTML = `${t('profiles.tabs.content_label', 'Content')} <span class="vrcn-badge fd-tab-badge">${_mypAllWorlds.length + _mypAllAvatars.length}</span>`;
 }
 
 function renderMypWorldsPage(page) {
@@ -910,7 +910,7 @@ function renderMypFavWorlds(payload) {
     let pillsHtml = `<div class="fd-content-pills">`;
     groups.forEach((g, i) => {
         const count = g.worlds ? g.worlds.length : 0;
-        pillsHtml += `<button class="fd-tab fd-content-pill${i === activePill ? ' active' : ''}" onclick="switchMypFavPill(${i},this)">${esc(g.displayName || g.name)} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${count}</span></button>`;
+        pillsHtml += `<button class="fd-tab fd-content-pill${i === activePill ? ' active' : ''}" onclick="switchMypFavPill(${i},this)">${esc(g.displayName || g.name)} <span class="vrcn-badge fd-tab-badge">${count}</span></button>`;
     });
     pillsHtml += `</div>`;
 

--- a/frontend/core/modals/my-profile-modal/my-profile-modal.js
+++ b/frontend/core/modals/my-profile-modal/my-profile-modal.js
@@ -97,11 +97,7 @@ function renderProfileDecoPicker(loading) {
             return `<div class="pd-section"><div class="pd-section-title">${esc(s.label)}</div><div class="pd-grid">${noneCell}${cells}</div>${empty}</div>`;
         }).join('') + _mypThemeSection() + _mypBackgroundSection();
     m.innerHTML = `<div class="gp-modal" style="width:560px;max-width:92vw;max-height:80vh;display:flex;flex-direction:column;">
-        <div class="gp-modal-header">
-            <span class="msi" style="font-size:20px;color:var(--accent);">filter_frames</span>
-            <span>${t('profiles.deco.title', 'Customize Profile')}</span>
-            <button class="vrcn-button-round" onclick="closeProfileDecoPicker()" title="${esc(t('common.close', 'Close'))}"><span class="msi" style="font-size:18px;">close</span></button>
-        </div>
+        ${renderModalBar(t('profiles.deco.title', 'Customize Profile'), [modalCloseAction('closeProfileDecoPicker()')])}
         <div class="gp-modal-body" style="flex:1;overflow-y:auto;">${body}</div>
     </div>`;
 }
@@ -158,8 +154,8 @@ function renderMyProfileContent() {
         : `<div style="display:flex;justify-content:flex-end;padding:4px 0 2px 0;"><button class="myp-edit-btn" onclick="openImagePicker('profile-banner')" title="${esc(addBannerTitle)}"><span class="msi" style="font-size:13px;">edit</span><span style="font-size:11px;margin-left:3px;">${esc(bannerLabel)}</span></button></div>`;
     const bannerCompactHtml = `<div class="fd-left-banner" id="myp-banner-slot">${bannerSrc ? `<div class="fd-banner-fade"></div>` : ''}${_mypEffect}<span class="vrcn-keybind" style="position:absolute;top:8px;right:8px;z-index:3;border-radius:5px;">CTRL P</span></div>`;
     const mypHeaderActions = renderModalActions([
-        { icon: 'edit', title: changeBannerTitle, onclick: `openImagePicker('profile-banner')`, header: true },
-        { icon: 'filter_frames', title: t('profiles.deco.title', 'Customize Profile'), onclick: `openProfileDecoPicker()`, header: true },
+        { icon: 'edit', title: changeBannerTitle, onclick: `openImagePicker('profile-banner')` },
+        { icon: 'filter_frames', title: t('profiles.deco.title', 'Customize Profile'), onclick: `openProfileDecoPicker()` },
         {
             label: 'VRCN+',
             title: t('vrcnplus.dropdown.title', 'VRCN+'),
@@ -169,7 +165,7 @@ function renderMyProfileContent() {
             ],
         },
         { icon: 'link_2', title: t('common.share', 'Share'), onclick: `navigator.clipboard.writeText('https://vrchat.com/home/user/${esc(u.id)}').then(()=>showToast(true,t('common.link_copied','Link copied!')))` },
-        { icon: 'close', title: t('common.close', 'Close'), onclick: `closeMyProfile()`, header: true },
+        { icon: 'close', title: t('common.close', 'Close'), onclick: `closeMyProfile()` },
     ]);
 
     // Avatar with edit overlay
@@ -1148,11 +1144,7 @@ function setProfileBackgroundGradient() {
     m.style.zIndex = '10004';
     m.style.display = 'flex';
     m.innerHTML = `<div class="gp-modal" style="width:380px;max-width:92vw;">
-        <div class="gp-modal-header">
-            <span class="msi" style="font-size:20px;color:var(--accent);">gradient</span>
-            <span>${esc(t('profiles.deco.gradient', 'Gradient'))}</span>
-            <button class="vrcn-button-round" onclick="closeProfileGradPicker()" title="${esc(t('common.close', 'Close'))}"><span class="msi" style="font-size:18px;">close</span></button>
-        </div>
+        ${renderModalBar(t('profiles.deco.gradient', 'Gradient'), [modalCloseAction('closeProfileGradPicker()')])}
         <div class="gp-modal-body">
             <div id="pbgPreview" class="pbg-preview"></div>
             <div class="pbg-row">
@@ -1167,7 +1159,6 @@ function setProfileBackgroundGradient() {
             </div>
         </div>
         <div class="modal-btns" style="padding:0 16px 16px;">
-            <button class="vrcn-button" onclick="closeProfileGradPicker()">${esc(t('common.cancel', 'Cancel'))}</button>
             <button class="vrcn-button vrcn-btn-primary" onclick="applyProfileGradient()">${esc(t('common.apply', 'Apply'))}</button>
         </div>
     </div>`;
@@ -1297,11 +1288,7 @@ function openProfileThemeEditor(themeId) {
     </div>`).join('');
 
     m.innerHTML = `<div class="gp-modal" style="width:400px;max-width:92vw;">
-        <div class="gp-modal-header">
-            <span class="msi" style="font-size:20px;color:var(--accent);">palette</span>
-            <span>${esc(themeId ? t('profiles.theme.edit', 'Edit Theme') : t('profiles.theme.add', 'New Theme'))}</span>
-            <button class="vrcn-button-round" onclick="closeProfileThemeEditor()" title="${esc(t('common.close', 'Close'))}"><span class="msi" style="font-size:18px;">close</span></button>
-        </div>
+        ${renderModalBar(themeId ? t('profiles.theme.edit', 'Edit Theme') : t('profiles.theme.add', 'New Theme'), [modalCloseAction('closeProfileThemeEditor()')])}
         <div class="gp-modal-body">
             <div class="pt-preview" id="ptPreview"></div>
             <div class="pt-row">
@@ -1311,7 +1298,6 @@ function openProfileThemeEditor(themeId) {
             ${rows}
         </div>
         <div class="modal-btns" style="padding:0 16px 16px;">
-            <button class="vrcn-button" onclick="closeProfileThemeEditor()">${esc(t('common.cancel', 'Cancel'))}</button>
             <button class="vrcn-button vrcn-btn-primary" onclick="saveProfileThemeFromEditor()">${esc(t('common.save', 'Save'))}</button>
         </div>
     </div>`;

--- a/frontend/core/modals/my-profile-modal/status-modal.html
+++ b/frontend/core/modals/my-profile-modal/status-modal.html
@@ -1,11 +1,17 @@
         <div class="modal-box" style="max-width:418px;">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px;"><div class="modal-title" style="margin-bottom:0;" data-i18n="profiles.status.modal_title">Change Status</div><div class="vrcn-keybind-row" aria-label="Keyboard shortcuts"><span class="vrcn-keybind">CTRL I</span></div></div>
-            <div id="statusOptions"></div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="profiles.status.modal_title">Change Status</span></div>
+                <div class="fd-modal-bar-actions">
+                    <div class="vrcn-keybind-row" aria-label="Keyboard shortcuts" style="margin-right:6px;"><span class="vrcn-keybind">CTRL I</span></div>
+                    <button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalStatus').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button>
+                </div>
+            </div>
+            <div id="statusOptions" style="margin-top:20px;"></div>
             <div class="status-desc-row" style="display:flex;gap:8px;align-items:center;margin-top:12px;">
                 <select class="vrcn-dropdown status-desc-select" id="statusDescSelect" style="flex:1;min-width:0;"></select>
                 <textarea class="status-desc-input" id="statusDescInput" rows="1" maxlength="32" placeholder="Status message..." data-i18n-placeholder="profiles.status.message_placeholder" style="flex:1;min-width:0;margin-top:0;display:none;"></textarea>
                 <button class="vrcn-button-round" id="statusDescEditBtn" onclick="toggleStatusDescEdit()" title="Custom message" data-i18n-title="profiles.status.custom"><span class="msi" style="font-size:16px;">edit</span></button>
             </div>
             <div style="font-size:10px;color:var(--tx3);margin-top:4px;margin-bottom:14px;text-align:right;" id="statusDescCount">0/32</div>
-            <div class="modal-btns"><button class="vrcn-button-round" onclick="document.getElementById('modalStatus').style.display='none'" data-i18n="common.cancel">Cancel</button><button class="vrcn-button-round vrcn-btn-join" onclick="submitStatusChange()" data-i18n="profiles.status.update">Update</button></div>
+            <div class="modal-btns"><button class="vrcn-button-round vrcn-btn-join" onclick="submitStatusChange()" data-i18n="profiles.status.update">Update</button></div>
         </div>

--- a/frontend/core/modals/notification-respond-modal/notification-respond-modal.js
+++ b/frontend/core/modals/notification-respond-modal/notification-respond-modal.js
@@ -62,6 +62,7 @@ function openNotifRespondModal(notifId) {
     el.style.zIndex = '20003';
     el.innerHTML = `
         <div class="modal-box inv-single-modal">
+            ${renderModalBar(_nrModalSenderName, [modalCloseAction('closeNotifRespondModal()')], { flush: true })}
             <div class="inv-world-banner" style="${bannerImg ? `background-image:url('${cssUrl(bannerImg)}')` : ''}">
                 <div class="inv-world-fade"></div>
                 <div class="inv-world-info">
@@ -69,7 +70,6 @@ function openNotifRespondModal(notifId) {
                     <div class="inv-world-name">${tf('notifications.respond.answer', { name: esc(_nrModalSenderName) }, 'Answer {name}')}</div>
                     ${subLine ? `<div style="font-size:11px;color:rgba(255,255,255,.75);margin-top:3px;">${subLine}</div>` : ''}
                 </div>
-                <button class="inv-close-btn" onclick="closeNotifRespondModal()"><span class="msi" style="font-size:18px;">close</span></button>
             </div>
             <div class="fd-tabs" style="margin:14px 16px 0;flex-shrink:0;">
                 <button class="fd-tab active" id="nrTab_message" onclick="_nrModalSetTab('message')">${t('profiles.invite.tab.message', 'With Message')}</button>

--- a/frontend/core/modals/timeline-modal/timeline-modal.css
+++ b/frontend/core/modals/timeline-modal/timeline-modal.css
@@ -135,6 +135,13 @@
     overflow: hidden;
 }
 
+.modal-overlay.tl-style-compact #detailModalContent .fd-modal-bar,
+.modal-overlay.tl-style-compact #detailModalContent2 .fd-modal-bar {
+    margin: 0;
+    border-radius: 0;
+    flex-shrink: 0;
+}
+
 .modal-overlay.tl-style-compact .fd-layout {
     flex: 1 1 0;
     min-height: 0;

--- a/frontend/core/modals/timeline-modal/timeline-modal.css
+++ b/frontend/core/modals/timeline-modal/timeline-modal.css
@@ -127,7 +127,8 @@
 /* === Compact two-column layout (instance detail) === */
 
 .modal-overlay.tl-style-compact #detailModalContent,
-.modal-overlay.tl-style-compact #detailModalContent2 {
+.modal-overlay.tl-style-compact #detailModalContent2,
+.modal-overlay.tl-style-compact #ftGpsDetailContent {
     padding: 0;
     height: min(calc(100vh - var(--tb-h, 0px) - 80px), 420px);
     display: flex;
@@ -136,7 +137,8 @@
 }
 
 .modal-overlay.tl-style-compact #detailModalContent .fd-modal-bar,
-.modal-overlay.tl-style-compact #detailModalContent2 .fd-modal-bar {
+.modal-overlay.tl-style-compact #detailModalContent2 .fd-modal-bar,
+.modal-overlay.tl-style-compact #ftGpsDetailContent .fd-modal-bar {
     margin: 0;
     border-radius: 0;
     flex-shrink: 0;

--- a/frontend/core/modals/timeline-modal/timeline-modal.js
+++ b/frontend/core/modals/timeline-modal/timeline-modal.js
@@ -5,11 +5,6 @@
 // underlying modal stays open — same behaviour as the profile modal.
 let _tlMid = 'modalDetail';
 
-function _instanceLinkBtn(location, closeJs) {
-    if (!location || location.indexOf(':') <= 0 || !location.startsWith('wrld_')) return '';
-    return `<button class="vrcn-button-round" onclick="${closeJs ? closeJs + ';' : ''}copyInstanceLink('${jsq(location)}')"><span class="msi" style="font-size:14px;">content_copy</span> ${esc(t('timeline.actions.copy_instance_link', 'Copy Instance Link'))}</button>`;
-}
-
 function openTlDetail(id) {
     const ev = timelineEvents.find(e => e.id === id)
              || _tlSearchEvents.find(e => e.id === id)
@@ -476,19 +471,20 @@ function openFtGpsDetail(evId) {
              || _ftlSearchEvents.find(e => e.id === evId);
     if (!ev) return;
     renderFtGpsDetailModal(ev);
-    const _ftMb = document.getElementById('ftGpsDetailContent');
-    if (_ftMb) _ftMb.classList.add('narrow');
-    document.getElementById('modalFtGpsDetail').style.display = 'flex';
+    _ftGpsShowModal();
+}
+
+function _ftGpsShowModal() {
+    const box = document.getElementById('ftGpsDetailContent');
+    if (box) box.classList.remove('narrow');
+    const ov = document.getElementById('modalFtGpsDetail');
+    if (!ov) return;
+    ov.classList.add('tl-style-compact');
+    ov.style.display = 'flex';
 }
 
 function closeFtGpsDetail() {
     document.getElementById('modalFtGpsDetail').style.display = 'none';
-}
-
-function switchFtGpsTab(tab) {
-    document.getElementById('ftGpsTabInfo').style.display = tab === 'info' ? '' : 'none';
-    document.getElementById('ftGpsTabAlso').style.display = tab === 'also' ? '' : 'none';
-    document.querySelectorAll('#ftGpsDetailContent .ftgps-tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
 }
 
 function renderFtGpsDetailModal(ev) {
@@ -502,9 +498,6 @@ function renderFtGpsDetailModal(ev) {
     const { dateStr, timeStr } = ftDetailDatetime(ev);
 
     const worldName = ev.worldName || ev.worldId || t('timeline.unknown_world', 'Unknown World');
-
-    // Was Also Here: populated async from server (covers all pages, not just loaded memory)
-    const alsoList = [];
 
     const fromStr = ev.timestamp ? tlFormatTime(ev.timestamp) : null;
     const toStr   = ev.leftAt    ? tlFormatTime(ev.leftAt)    : null;
@@ -520,25 +513,37 @@ function renderFtGpsDetailModal(ev) {
         _tlMr(esc(t('timeline.detail.event', 'Event')), `<span style="color:var(--tx2);">${esc(tf('timeline.detail.friend_joined_world', { name: ev.friendName || t('timeline.unknown', 'Unknown') }, `${ev.friendName || 'Unknown'} joined this world`))}</span>`),
     ].filter(Boolean).join(''));
 
-    const banner = _tlBanner(!!ev.worldThumb);
-    const el = document.getElementById('ftGpsDetailContent');
-    el.innerHTML = `${renderModalBar(worldName, [modalCloseAction('closeFtGpsDetail()')])}${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:16px 0;">
-        ${ftDetailAvRow(ev)}
-        <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(worldName)}</h2>
-        <div style="margin-bottom:12px;">${idBadge(ev.worldId || '')}</div>
-        <div class="fd-tabs" style="margin-bottom:14px;">
-            <button class="fd-tab active ftgps-tab-btn" data-tab="info" onclick="switchFtGpsTab('info')">${esc(t('timeline.detail.info', 'Info'))}</button>
-            <button class="fd-tab ftgps-tab-btn" data-tab="also" id="ftGpsAlsoTab" onclick="switchFtGpsTab('also')">${esc(t('timeline.detail.was_also_here', 'Was also here'))}</button>
-        </div>
-        <div id="ftGpsTabInfo">${infoHtml}</div>
-        <div id="ftGpsTabAlso" style="display:none;"><div style="font-size:12px;color:var(--tx3);padding:12px 0;">${esc(t('common.loading', 'Loading...'))}</div></div>
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${loc ? `<button class="vrcn-button-round vrcn-btn-join" onclick="closeFtGpsDetail();sendToCS({action:'vrcJoinFriend',location:'${jsq(loc)}'});">${esc(t('instance.actions.force_join', 'Force-Join'))}</button>` : ''}
-            ${_instanceLinkBtn(loc, '')}
-            <span style="flex:1;"></span>
-            ${ev.worldId ? `<button class="vrcn-button-round" onclick="closeFtGpsDetail();openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:14px;">travel_explore</span> ${esc(t('timeline.actions.open_world', 'Open World'))}</button>` : ''}
+    const canCopyLink = !!(loc && loc.indexOf(':') > 0 && loc.startsWith('wrld_'));
+
+    const leftHtml = `<div class="fd-left">
+        <div class="fd-left-banner" id="tl-banner-slot">${ev.worldThumb ? '<div class="fd-banner-fade"></div>' : ''}</div>
+        <div class="fd-left-body">
+            ${ftDetailAvRow(ev)}
+            <div>
+                <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(worldName)}</h2>
+                <div style="font-size:12px;color:var(--tx3);margin-bottom:8px;">${esc(dateStr)}</div>
+                ${idBadge(ev.worldId || '')}
+            </div>
+            <div class="fd-actions">
+                ${loc ? `<button class="vrcn-button-round vrcn-btn-join" title="${esc(t('instance.actions.force_join', 'Force-Join'))}" onclick="closeFtGpsDetail();sendToCS({action:'vrcJoinFriend',location:'${jsq(loc)}'});"><span class="msi" style="font-size:16px;">play_arrow</span></button>` : ''}
+                ${canCopyLink ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.copy_instance_link', 'Copy Instance Link'))}" onclick="copyInstanceLink('${jsq(loc)}')"><span class="msi" style="font-size:16px;">content_copy</span></button>` : ''}
+                ${ev.worldId ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.open_world', 'Open World'))}" onclick="closeFtGpsDetail();openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:16px;">travel_explore</span></button>` : ''}
+            </div>
+            ${infoHtml}
         </div>
     </div>`;
+
+    const rightHtml = `<div class="fd-right">
+        <div class="tl-players-head">
+            <div class="fd-group-rep-label" id="ftGpsAlsoTab" style="margin-bottom:0;">${esc(t('timeline.detail.was_also_here', 'Was also here'))}</div>
+        </div>
+        <div class="fd-right-scroll" id="ftGpsTabAlso">
+            <div style="font-size:12px;color:var(--tx3);padding:12px 0;">${esc(t('common.loading', 'Loading...'))}</div>
+        </div>
+    </div>`;
+
+    const el = document.getElementById('ftGpsDetailContent');
+    el.innerHTML = `${renderModalBar(worldName, [modalCloseAction('closeFtGpsDetail()')])}<div class="fd-layout">${leftHtml}${rightHtml}</div>`;
 
     // Async: ask server for all friends at this location (searches full DB, not just loaded page)
     _tlInsertBanner(el, ev.worldId || ev.id, ev.worldThumb);
@@ -594,9 +599,7 @@ function openFdActivityDetail(id) {
     if (!ev) return;
     if (ev.type === 'friend_gps') {
         renderFtGpsDetailModal(ev);
-        const _ftMb = document.getElementById('ftGpsDetailContent');
-        if (_ftMb) _ftMb.classList.add('narrow');
-        document.getElementById('modalFtGpsDetail').style.display = 'flex';
+        _ftGpsShowModal();
         return;
     }
     _tlMid = 'modalDetail';

--- a/frontend/core/modals/timeline-modal/timeline-modal.js
+++ b/frontend/core/modals/timeline-modal/timeline-modal.js
@@ -90,8 +90,8 @@ function _tlMr(label, val) {
 function _tlInfoCard(title, rowsHtml) {
     return `<div class="fd-info-card"><div class="fd-group-rep-label">${title}</div><div style="display:grid;gap:6px;">${rowsHtml}</div></div>`;
 }
-function _tlClose() {
-    return `<button class="vrcn-button-round" style="margin-left:auto;" onclick="document.getElementById('${_tlMid}').style.display='none'">${esc(t('common.close', 'Close'))}</button>`;
+function _tlBar(title) {
+    return renderModalBar(title, [modalCloseAction(`document.getElementById('${_tlMid}').style.display='none'`)]);
 }
 function _tlBanner(hasThumb) {
     return hasThumb ? `<div class="fd-banner" id="tl-banner-slot"><div class="fd-banner-fade"></div></div>` : '';
@@ -259,7 +259,6 @@ function renderTlDetailJoin(ev, el) {
             <div class="fd-actions">
                 <button class="vrcn-button-round vrcn-btn-join" title="${esc(t('instance.actions.force_join', 'Force-Join'))}" onclick="document.getElementById('${_tlMid}').style.display='none';sendToCS({action:'vrcJoinFriend',location:'${jsq(ev.location)}'});"><span class="msi" style="font-size:16px;">play_arrow</span></button>
                 ${canCopyLink ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.copy_instance_link', 'Copy Instance Link'))}" onclick="copyInstanceLink('${jsq(ev.location)}')"><span class="msi" style="font-size:16px;">content_copy</span></button>` : ''}
-                <button class="vrcn-button-round" title="${esc(t('common.close', 'Close'))}" onclick="document.getElementById('${_tlMid}').style.display='none'"><span class="msi" style="font-size:16px;">close</span></button>
             </div>
             ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         </div>
@@ -285,7 +284,7 @@ function renderTlDetailJoin(ev, el) {
         </div>
     </div>`;
 
-    el.innerHTML = `<div class="fd-layout">${leftHtml}${rightHtml}</div>`;
+    el.innerHTML = `${_tlBar(ev.worldName || ev.worldId || t('timeline.unknown_world', 'Unknown World'))}<div class="fd-layout">${leftHtml}${rightHtml}</div>`;
     const _tlSortSel = el.querySelector('#tlPlayersSort');
     if (_tlSortSel && typeof initVnSelect === 'function') initVnSelect(_tlSortSel);
     _tlInsertBanner(el, ev.worldId || ev.id, ev.worldThumb);
@@ -302,13 +301,12 @@ function renderTlDetailMeet(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         ev.worldId ? `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;"${worldRowClick}><span style="color:var(--tx3);">${esc(t('timeline.detail.world', 'World'))}</span><span style="color:var(--accent-lt);text-align:right;">${esc(ev.worldName || ev.worldId)}</span></div>` : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(ev.userName || t('timeline.unknown', 'Unknown'))}<div class="fd-content" style="padding:20px 0;">
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.first_meet', 'FIRST MEET'), 'var(--cyan)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.userId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>` : ''}
-            ${_tlClose()}
-        </div>
+        ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
+            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+        </div>` : ''}
     </div>`;
 }
 
@@ -323,13 +321,12 @@ function renderTlDetailMeetAgain(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         ev.worldId ? `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;"${worldRowClick}><span style="color:var(--tx3);">${esc(t('timeline.detail.world', 'World'))}</span><span style="color:var(--accent-lt);text-align:right;">${esc(ev.worldName || ev.worldId)}</span></div>` : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(ev.userName || t('timeline.unknown', 'Unknown'))}<div class="fd-content" style="padding:20px 0;">
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.met_again', 'MET AGAIN'), '#AB47BC')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.userId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>` : ''}
-            ${_tlClose()}
-        </div>
+        ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
+            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+        </div>` : ''}
     </div>`;
 }
 
@@ -346,13 +343,12 @@ function renderTlDetailNotif(ev, el) {
         ev.notifTitle ? _tlMr(esc(t('timeline.detail.context', 'Context')), esc(ev.notifTitle)) : '',
         ev.message    ? _tlMr(esc(t('timeline.detail.message', 'Message')), esc(ev.message))    : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(ev.senderName || typeLabel)}<div class="fd-content" style="padding:20px 0;">
         ${_tlAvRow(ev.senderImage, ev.senderName || typeLabel, typeLabel.toUpperCase(), 'var(--warn)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.senderId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.senderId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>` : ''}
-            ${_tlClose()}
-        </div>
+        ${ev.senderId ? `<div style="margin-top:14px;display:flex;gap:8px;">
+            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.senderId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+        </div>` : ''}
     </div>`;
 }
 
@@ -367,13 +363,12 @@ function renderTlDetailAvatar(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         ev.userId ? _tlMr(esc(t('timeline.detail.avatar_id', 'Avatar ID')), `<span style="font-size:11px;color:var(--tx3);">${esc(ev.userId)}</span>`) : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(ev.userName || t('timeline.unknown_avatar', 'Unknown Avatar'))}${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
         <h2 style="margin:0 0 12px;color:var(--tx0);font-size:18px;">${esc(ev.userName || t('timeline.unknown_avatar', 'Unknown Avatar'))}</h2>
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.userId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openAvatarDetail('${jsq(ev.userId)}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>` : ''}
-            ${_tlClose()}
-        </div>
+        ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
+            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openAvatarDetail('${jsq(ev.userId)}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>
+        </div>` : ''}
     </div>`;
     _tlInsertBanner(el, ev.userId || ev.id, ev.userImage);
 }
@@ -393,7 +388,7 @@ function renderTlDetailUrl(ev, el) {
         ev.worldName ? `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;"${worldRowClick}><span style="color:var(--tx3);">${esc(t('timeline.detail.world', 'World'))}</span><span style="color:var(--accent-lt);text-align:right;">${esc(ev.worldName)}</span></div>` : '',
         _tlMr(esc(t('timeline.detail.url', 'URL')), `<span style="word-break:break-all;font-size:11px;color:var(--tx2);">${esc(url)}</span>`),
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(plat.name)}<div class="fd-content" style="padding:20px 0;">
         <div style="display:flex;gap:16px;align-items:center;margin-bottom:16px;">
             ${favicon}
             <div>
@@ -405,7 +400,6 @@ function renderTlDetailUrl(ev, el) {
         <div style="margin-top:14px;display:flex;gap:8px;">
             <button class="vrcn-button-round vrcn-btn-join" onclick="sendToCS({action:'openUrl',url:'${jsq(url)}'})">${esc(t('timeline.actions.open_url', 'Open URL'))}</button>
             <button class="vrcn-button-round" onclick="navigator.clipboard.writeText('${jsq(url)}').then(()=>showToast(true,t('timeline.toast.copied','Copied!')))">${esc(t('timeline.actions.copy', 'Copy'))}</button>
-            ${_tlClose()}
         </div>
     </div>`;
 }
@@ -422,13 +416,12 @@ function renderTlDetailModeration(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         _tlMr(esc(t('timeline.detail.moderation_type', 'Moderation Type')), `<span style="color:${active ? 'var(--err)' : 'var(--ok)'};font-weight:600;">${esc(label)}</span>`),
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(ev.userName || label)}<div class="fd-content" style="padding:20px 0;">
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.moderation', 'MODERATION'), 'var(--err)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.userId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>` : ''}
-            ${_tlClose()}
-        </div>
+        ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
+            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+        </div>` : ''}
     </div>`;
 }
 
@@ -461,7 +454,7 @@ function renderTlDetailProfile(ev, el) {
         ${ev.message ? `<div class="fd-info-card" style="margin-top:10px;"><div class="fd-group-rep-label">${esc(t('timeline.detail.new_bio', 'NEW BIO'))}</div><div style="font-size:12px;color:var(--tx1);white-space:pre-wrap;">${esc(ev.message)}</div></div>` : ''}`;
     }
 
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${_tlBar(meta.label)}<div class="fd-content" style="padding:20px 0;">
         <div style="display:flex;gap:16px;align-items:center;margin-bottom:16px;">
             ${ev.userImage
                 ? `<div class="tl-detail-av" style="background-image:url('${cssUrl(ev.userImage)}')"></div>`
@@ -473,9 +466,6 @@ function renderTlDetailProfile(ev, el) {
         </div>
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoHtml)}
         ${extraCards}
-        <div style="margin-top:14px;display:flex;gap:8px;">
-            ${_tlClose()}
-        </div>
     </div>`;
 }
 
@@ -532,7 +522,7 @@ function renderFtGpsDetailModal(ev) {
 
     const banner = _tlBanner(!!ev.worldThumb);
     const el = document.getElementById('ftGpsDetailContent');
-    el.innerHTML = `${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:16px 0;">
+    el.innerHTML = `${renderModalBar(worldName, [modalCloseAction('closeFtGpsDetail()')])}${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:16px 0;">
         ${ftDetailAvRow(ev)}
         <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(worldName)}</h2>
         <div style="margin-bottom:12px;">${idBadge(ev.worldId || '')}</div>
@@ -547,7 +537,6 @@ function renderFtGpsDetailModal(ev) {
             ${_instanceLinkBtn(loc, '')}
             <span style="flex:1;"></span>
             ${ev.worldId ? `<button class="vrcn-button-round" onclick="closeFtGpsDetail();openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:14px;">travel_explore</span> ${esc(t('timeline.actions.open_world', 'Open World'))}</button>` : ''}
-            <button class="vrcn-button-round" onclick="closeFtGpsDetail()">${esc(t('common.close', 'Close'))}</button>
         </div>
     </div>`;
 
@@ -645,8 +634,8 @@ function ftDetailAvRow(ev) {
         </div></div>`;
 }
 
-function ftDetailClose() {
-    return `<button class="vrcn-button-round" style="margin-left:auto;" onclick="document.getElementById('${_tlMid}').style.display='none'">${esc(t('common.close', 'Close'))}</button>`;
+function ftDetailBar(ev) {
+    return _tlBar(ev.friendName || t('timeline.unknown', 'Unknown'));
 }
 
 function ftDetailViewProfile(ev) {
@@ -665,13 +654,12 @@ function renderFtDetailGps(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;"${worldRowClick}><span style="color:var(--tx3);">${esc(t('timeline.detail.world', 'World'))}</span><span style="color:var(--accent-lt);text-align:right;">${esc(wname)}</span></div>`,
     ].join('');
-    el.innerHTML = `${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         <div style="margin-top:14px;display:flex;gap:8px;">
             ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:14px;">travel_explore</span> ${esc(t('timeline.actions.open_world', 'Open World'))}</button>` : ''}
             ${ftDetailViewProfile(ev)}
-            ${ftDetailClose()}
         </div>
     </div>`;
     _tlInsertBanner(el, ev.worldId || ev.id, ev.worldThumb);
@@ -686,10 +674,10 @@ function renderFtDetailStatus(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         _tlMr(esc(t('timeline.detail.change', 'Change')), `<span style="display:flex;align-items:center;gap:6px;"><span class="ft-status-chip ${oldCls}">${esc(statusLabel(ev.oldValue) || '?')}</span><span class="msi" style="font-size:12px;color:var(--tx3);">arrow_forward</span><span class="ft-status-chip ${newCls}">${esc(statusLabel(ev.newValue) || '?')}</span></span>`),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -700,10 +688,10 @@ function renderFtDetailOnline(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         _tlMr(esc(t('timeline.detail.event', 'Event')), `<span style="color:var(--ok);">${esc(t('timeline.friend.online_game', 'Online (Game)'))}</span>`),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -714,10 +702,10 @@ function renderFtDetailOffline(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         _tlMr(esc(t('timeline.detail.event', 'Event')), `<span style="color:var(--tx3);">${esc(t('timeline.friend.went_offline', 'Went Offline'))}</span>`),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -728,10 +716,10 @@ function renderFtDetailAdded(ev, el) {
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
         _tlMr(esc(t('timeline.detail.event', 'Event')), `<span style="color:var(--ok);">${esc(t('timeline.friend.added_full', 'Friend Added'))}</span>`),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -743,10 +731,10 @@ function renderFtDetailRemoved(ev, el) {
         _tlMr(esc(t('timeline.detail.event', 'Event')), `<span style="color:var(--err);">${esc(t('timeline.friend.unfriended', 'Unfriended'))}</span>`),
         ev.friendId ? _tlMr(esc(t('timeline.detail.user_id', 'User ID')), `<span style="font-size:11px;opacity:.7;">${esc(ev.friendId)}</span>`) : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -756,12 +744,12 @@ function renderFtDetailStatusDesc(ev, el) {
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.oldValue ? `<div class="fd-info-card" style="margin-top:10px;"><div class="fd-group-rep-label">${esc(t('timeline.detail.previous_status_text', 'PREVIOUS STATUS TEXT'))}</div><div style="font-size:12px;color:var(--tx2);white-space:pre-wrap;">${esc(ev.oldValue)}</div></div>` : ''}
         ${ev.newValue !== undefined ? `<div class="fd-info-card" style="margin-top:10px;"><div class="fd-group-rep-label">${esc(t('timeline.detail.new_status_text', 'NEW STATUS TEXT'))}</div><div style="font-size:12px;color:var(--tx1);white-space:pre-wrap;">${ev.newValue ? esc(ev.newValue) : tlDetailClearedHtml()}</div></div>` : ''}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -771,12 +759,12 @@ function renderFtDetailBio(ev, el) {
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
     ].join('');
-    el.innerHTML = `<div class="fd-content" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}<div class="fd-content" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.oldValue ? `<div class="fd-info-card" style="margin-top:10px;"><div class="fd-group-rep-label">${esc(t('timeline.detail.previous_bio', 'PREVIOUS BIO'))}</div><div style="font-size:12px;color:var(--tx2);white-space:pre-wrap;">${esc(ev.oldValue)}</div></div>` : ''}
         ${ev.newValue ? `<div class="fd-info-card" style="margin-top:10px;"><div class="fd-group-rep-label">${esc(t('timeline.detail.new_bio', 'NEW BIO'))}</div><div style="font-size:12px;color:var(--tx1);white-space:pre-wrap;">${esc(ev.newValue)}</div></div>` : ''}
-        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}${ftDetailClose()}</div>
+        <div style="margin-top:14px;display:flex;gap:8px;">${ftDetailViewProfile(ev)}</div>
     </div>`;
 }
 
@@ -789,12 +777,12 @@ function renderFtDetailFriendAvatar(ev, el) {
         ev.worldName ? _tlMr(esc(t('timeline.detail.avatar', 'Avatar')), `<span style="color:var(--accent-lt);">${esc(ev.worldName)}</span>`) : '',
         ev.worldId   ? _tlMr(esc(t('timeline.detail.avatar_id', 'Avatar ID')), `<span style="font-size:11px;color:var(--tx3);">${esc(ev.worldId)}</span>`) : '',
     ].filter(Boolean).join('');
-    el.innerHTML = `${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
+    el.innerHTML = `${ftDetailBar(ev)}${banner}<div class="fd-content${banner ? ' fd-has-banner' : ''}" style="padding:20px 0;">
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         <div style="margin-top:14px;display:flex;gap:8px;">
             ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openAvatarDetail('${jsq(ev.worldId)}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>` : ''}
-            ${ftDetailViewProfile(ev)}${ftDetailClose()}
+            ${ftDetailViewProfile(ev)}
         </div>
     </div>`;
     _tlInsertBanner(el, ev.worldId || ev.id, ev.worldThumb);

--- a/frontend/core/modals/timeline-modal/timeline-modal.js
+++ b/frontend/core/modals/timeline-modal/timeline-modal.js
@@ -35,6 +35,8 @@ function openTlDetail(id) {
     const el = document.getElementById(mainOpen ? 'detailModalContent2' : 'detailModalContent');
     if (!el) return;
 
+    if (!mainOpen && typeof navSetCurrent === 'function') navSetCurrent('tlEvent', id);
+
     switch (ev.type) {
         case 'instance_join': renderTlDetailJoin(ev, el);      break;
         case 'first_meet':    renderTlDetailMeet(ev, el);      break;
@@ -86,7 +88,14 @@ function _tlInfoCard(title, rowsHtml) {
     return `<div class="fd-info-card"><div class="fd-group-rep-label">${title}</div><div style="display:grid;gap:6px;">${rowsHtml}</div></div>`;
 }
 function _tlBar(title) {
-    return renderModalBar(title, [modalCloseAction(`document.getElementById('${_tlMid}').style.display='none'`)]);
+    if (_tlMid === 'modalDetail' && typeof navUpdateLabel === 'function') navUpdateLabel(title);
+    return renderModalBar(title, [modalCloseAction('closeTlDetail()')]);
+}
+
+function closeTlDetail(fromNav = false) {
+    const ov = document.getElementById(_tlMid);
+    if (ov) ov.style.display = 'none';
+    if (!fromNav && typeof navClear === 'function') navClear();
 }
 function _tlBanner(hasThumb) {
     return hasThumb ? `<div class="fd-banner" id="tl-banner-slot"><div class="fd-banner-fade"></div></div>` : '';
@@ -124,7 +133,7 @@ function _tlPlayerCard(p, instanceStart, instanceEnd) {
         ? `<div class="tl-player-card-av" style="background-image:url('${cssUrl(image)}')"></div>`
         : `<div class="tl-player-card-av">${esc(name[0].toUpperCase())}</div>`;
     const badge  = live ? `<span class="vrcn-badge bdg-friend"><span class="msi" style="font-size:10px;">check_circle</span>${t('profiles.badges.friend', 'Friend')}</span>` : '';
-    const onclick = p.userId ? `onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${jsq(p.userId)}')"` : '';
+    const onclick = p.userId ? `onclick="navOpenModal('friend','${jsq(p.userId)}','${jsq(name)}')"` : '';
     const clickCls = p.userId ? ' clickable' : '';
 
     const { joins, lefts } = _tlPlayerSessions(p);
@@ -233,7 +242,7 @@ function renderTlDetailJoin(ev, el) {
     const instIdMatch = loc.match(/:(\d+)/);
     const instanceId  = instIdMatch ? instIdMatch[1] : '';
 
-    const worldRowClick = ev.worldId ? ` onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')" style="cursor:pointer;"` : '';
+    const worldRowClick = ev.worldId ? ` onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')" style="cursor:pointer;"` : '';
     const infoRows = [
         fromStr ? _tlMr(esc(t('timeline.detail.from', 'From')), esc(fromStr)) : '',
         (fromStr && ev.tracked) ? _tlMr(esc(t('timeline.detail.to', 'To')), toStr ? esc(toStr) : `<span style="color:var(--ok);">&#9679;&nbsp;${esc(t('timeline.detail.ongoing', 'Ongoing'))}</span>`) : '',
@@ -252,7 +261,7 @@ function renderTlDetailJoin(ev, el) {
                 <div style="font-size:12px;color:var(--tx3);margin-bottom:12px;">${esc(dateStr)}</div>
             </div>
             <div class="fd-actions">
-                <button class="vrcn-button-round vrcn-btn-join" title="${esc(t('instance.actions.force_join', 'Force-Join'))}" onclick="document.getElementById('${_tlMid}').style.display='none';sendToCS({action:'vrcJoinFriend',location:'${jsq(ev.location)}'});"><span class="msi" style="font-size:16px;">play_arrow</span></button>
+                <button class="vrcn-button-round vrcn-btn-join" title="${esc(t('instance.actions.force_join', 'Force-Join'))}" onclick="closeTlDetail();sendToCS({action:'vrcJoinFriend',location:'${jsq(ev.location)}'});"><span class="msi" style="font-size:16px;">play_arrow</span></button>
                 ${canCopyLink ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.copy_instance_link', 'Copy Instance Link'))}" onclick="copyInstanceLink('${jsq(ev.location)}')"><span class="msi" style="font-size:16px;">content_copy</span></button>` : ''}
             </div>
             ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
@@ -290,7 +299,7 @@ function renderTlDetailJoin(ev, el) {
 function renderTlDetailMeet(ev, el) {
     const dateStr = tlFormatLongDate(ev.timestamp);
     const timeStr = tlFormatTime(ev.timestamp);
-    const worldRowClick = ev.worldId ? ` onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')" style="cursor:pointer;"` : '';
+    const worldRowClick = ev.worldId ? ` onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')" style="cursor:pointer;"` : '';
     const infoRows = [
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
@@ -300,7 +309,7 @@ function renderTlDetailMeet(ev, el) {
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.first_meet', 'FIRST MEET'), 'var(--cyan)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
-            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+            <button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('friend','${jsq(ev.userId)}','${jsq(ev.userName || '')}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
         </div>` : ''}
     </div>`;
 }
@@ -310,7 +319,7 @@ function renderTlDetailMeet(ev, el) {
 function renderTlDetailMeetAgain(ev, el) {
     const dateStr = tlFormatLongDate(ev.timestamp);
     const timeStr = tlFormatTime(ev.timestamp);
-    const worldRowClick = ev.worldId ? ` onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')" style="cursor:pointer;"` : '';
+    const worldRowClick = ev.worldId ? ` onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')" style="cursor:pointer;"` : '';
     const infoRows = [
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
@@ -320,7 +329,7 @@ function renderTlDetailMeetAgain(ev, el) {
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.met_again', 'MET AGAIN'), '#AB47BC')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
-            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+            <button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('friend','${jsq(ev.userId)}','${jsq(ev.userName || '')}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
         </div>` : ''}
     </div>`;
 }
@@ -342,7 +351,7 @@ function renderTlDetailNotif(ev, el) {
         ${_tlAvRow(ev.senderImage, ev.senderName || typeLabel, typeLabel.toUpperCase(), 'var(--warn)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.senderId ? `<div style="margin-top:14px;display:flex;gap:8px;">
-            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.senderId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+            <button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('friend','${jsq(ev.senderId)}','${jsq(ev.senderName || '')}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
         </div>` : ''}
     </div>`;
 }
@@ -362,7 +371,7 @@ function renderTlDetailAvatar(ev, el) {
         <h2 style="margin:0 0 12px;color:var(--tx0);font-size:18px;">${esc(ev.userName || t('timeline.unknown_avatar', 'Unknown Avatar'))}</h2>
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
-            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openAvatarDetail('${jsq(ev.userId)}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>
+            <button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('avatar','${jsq(ev.userId)}','${jsq(ev.userName || '')}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>
         </div>` : ''}
     </div>`;
     _tlInsertBanner(el, ev.userId || ev.id, ev.userImage);
@@ -376,7 +385,7 @@ function renderTlDetailUrl(ev, el) {
     const url     = ev.message || '';
     const plat    = _urlPlatform(url);
     const favicon = `<div style="display:flex;align-items:center;justify-content:center;width:64px;height:64px;border-radius:12px;background:var(--bg2);">${_urlFaviconHtml(plat)}</div>`;
-    const worldRowClick = ev.worldId ? ` onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')" style="cursor:pointer;"` : '';
+    const worldRowClick = ev.worldId ? ` onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')" style="cursor:pointer;"` : '';
     const infoRows = [
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
@@ -415,7 +424,7 @@ function renderTlDetailModeration(ev, el) {
         ${_tlAvRow(ev.userImage, ev.userName, t('timeline.detail.moderation', 'MODERATION'), 'var(--err)')}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         ${ev.userId ? `<div style="margin-top:14px;display:flex;gap:8px;">
-            <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.userId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
+            <button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('friend','${jsq(ev.userId)}','${jsq(ev.userName || '')}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>
         </div>` : ''}
     </div>`;
 }
@@ -468,8 +477,10 @@ function renderTlDetailProfile(ev, el) {
 /* === Friend GPS Instance Log Modal === */
 function openFtGpsDetail(evId) {
     const ev = friendTimelineEvents.find(e => e.id === evId)
-             || _ftlSearchEvents.find(e => e.id === evId);
+             || _ftlSearchEvents.find(e => e.id === evId)
+             || (typeof _fdUserActivityEvents !== 'undefined' ? _fdUserActivityEvents.find(e => e.id === evId) : null);
     if (!ev) return;
+    if (typeof navSetCurrent === 'function') navSetCurrent('ftGps', evId);
     renderFtGpsDetailModal(ev);
     _ftGpsShowModal();
 }
@@ -483,8 +494,9 @@ function _ftGpsShowModal() {
     ov.style.display = 'flex';
 }
 
-function closeFtGpsDetail() {
+function closeFtGpsDetail(fromNav = false) {
     document.getElementById('modalFtGpsDetail').style.display = 'none';
+    if (!fromNav && typeof navClear === 'function') navClear();
 }
 
 function renderFtGpsDetailModal(ev) {
@@ -527,7 +539,7 @@ function renderFtGpsDetailModal(ev) {
             <div class="fd-actions">
                 ${loc ? `<button class="vrcn-button-round vrcn-btn-join" title="${esc(t('instance.actions.force_join', 'Force-Join'))}" onclick="closeFtGpsDetail();sendToCS({action:'vrcJoinFriend',location:'${jsq(loc)}'});"><span class="msi" style="font-size:16px;">play_arrow</span></button>` : ''}
                 ${canCopyLink ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.copy_instance_link', 'Copy Instance Link'))}" onclick="copyInstanceLink('${jsq(loc)}')"><span class="msi" style="font-size:16px;">content_copy</span></button>` : ''}
-                ${ev.worldId ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.open_world', 'Open World'))}" onclick="closeFtGpsDetail();openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:16px;">travel_explore</span></button>` : ''}
+                ${ev.worldId ? `<button class="vrcn-button-round" title="${esc(t('timeline.actions.open_world', 'Open World'))}" onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')"><span class="msi" style="font-size:16px;">travel_explore</span></button>` : ''}
             </div>
             ${infoHtml}
         </div>
@@ -541,6 +553,8 @@ function renderFtGpsDetailModal(ev) {
             <div style="font-size:12px;color:var(--tx3);padding:12px 0;">${esc(t('common.loading', 'Loading...'))}</div>
         </div>
     </div>`;
+
+    if (typeof navUpdateLabel === 'function') navUpdateLabel(worldName);
 
     const el = document.getElementById('ftGpsDetailContent');
     el.innerHTML = `${renderModalBar(worldName, [modalCloseAction('closeFtGpsDetail()')])}<div class="fd-layout">${leftHtml}${rightHtml}</div>`;
@@ -561,7 +575,7 @@ function renderFtAlsoWasHereResult(payload) {
         tab.innerHTML = friends.map(f =>
             renderProfileItemSmall(
                 { id: f.friendId, displayName: f.friendName || t('timeline.unknown', 'Unknown'), image: f.friendImage },
-                `closeFtGpsDetail();openFriendDetail('${jsq(f.friendId)}')`
+                `navOpenModal('friend','${jsq(f.friendId)}','${jsq(f.friendName || '')}')`
             )
         ).join('');
     }
@@ -570,11 +584,14 @@ function renderFtAlsoWasHereResult(payload) {
 
 function openFtDetail(id) {
     const ev = friendTimelineEvents.find(e => e.id === id)
-             || _ftlSearchEvents.find(e => e.id === id);
+             || _ftlSearchEvents.find(e => e.id === id)
+             || (typeof _fdUserActivityEvents !== 'undefined' ? _fdUserActivityEvents.find(e => e.id === id) : null);
     if (!ev) return;
     _tlMid = 'modalDetail';
     const el = document.getElementById('detailModalContent');
     if (!el) return;
+
+    if (typeof navSetCurrent === 'function') navSetCurrent('ftEvent', id);
 
     switch (ev.type) {
         case 'friend_gps':        renderFtDetailGps(ev, el);        break;
@@ -598,6 +615,7 @@ function openFdActivityDetail(id) {
     const ev = _fdUserActivityEvents.find(e => e.id === id);
     if (!ev) return;
     if (ev.type === 'friend_gps') {
+        if (typeof navSetCurrent === 'function') navSetCurrent('ftGps', id);
         renderFtGpsDetailModal(ev);
         _ftGpsShowModal();
         return;
@@ -605,6 +623,8 @@ function openFdActivityDetail(id) {
     _tlMid = 'modalDetail';
     const el = document.getElementById('detailModalContent');
     if (!el) return;
+
+    if (typeof navSetCurrent === 'function') navSetCurrent('ftEvent', id);
     switch (ev.type) {
         case 'friend_status':     renderFtDetailStatus(ev, el);     break;
         case 'friend_statusdesc': renderFtDetailStatusDesc(ev, el); break;
@@ -643,7 +663,7 @@ function ftDetailBar(ev) {
 
 function ftDetailViewProfile(ev) {
     return ev.friendId
-        ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openFriendDetail('${esc(ev.friendId)}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>`
+        ? `<button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('friend','${jsq(ev.friendId)}','${jsq(ev.friendName || '')}')">${esc(t('timeline.actions.view_profile', 'View Profile'))}</button>`
         : '';
 }
 
@@ -651,7 +671,7 @@ function renderFtDetailGps(ev, el) {
     const { dateStr, timeStr } = ftDetailDatetime(ev);
     const banner = _tlBanner(!!ev.worldThumb);
     const wname  = ev.worldName || ev.worldId || t('timeline.unknown_world', 'Unknown World');
-    const worldRowClick = ev.worldId ? ` onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')" style="cursor:pointer;"` : '';
+    const worldRowClick = ev.worldId ? ` onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')" style="cursor:pointer;"` : '';
     const infoRows = [
         _tlMr(esc(t('timeline.detail.date', 'Date')), esc(dateStr)),
         _tlMr(esc(t('timeline.detail.time', 'Time')), esc(timeStr)),
@@ -661,7 +681,7 @@ function renderFtDetailGps(ev, el) {
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openWorldSearchDetail('${esc(ev.worldId)}')"><span class="msi" style="font-size:14px;">travel_explore</span> ${esc(t('timeline.actions.open_world', 'Open World'))}</button>` : ''}
+            ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('worldSearch','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')"><span class="msi" style="font-size:14px;">travel_explore</span> ${esc(t('timeline.actions.open_world', 'Open World'))}</button>` : ''}
             ${ftDetailViewProfile(ev)}
         </div>
     </div>`;
@@ -784,7 +804,7 @@ function renderFtDetailFriendAvatar(ev, el) {
         ${ftDetailAvRow(ev)}
         ${_tlInfoCard(esc(t('timeline.detail.info', 'Info')), infoRows)}
         <div style="margin-top:14px;display:flex;gap:8px;">
-            ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('${_tlMid}').style.display='none';openAvatarDetail('${jsq(ev.worldId)}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>` : ''}
+            ${ev.worldId ? `<button class="vrcn-button-round vrcn-btn-join" onclick="navOpenModal('avatar','${jsq(ev.worldId)}','${jsq(ev.worldName || '')}')">${esc(t('timeline.actions.view_avatar', 'View Avatar'))}</button>` : ''}
             ${ftDetailViewProfile(ev)}
         </div>
     </div>`;

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -169,13 +169,13 @@
 #modalFriendDetail.fd-style-compact .modal-box.wide,
 #modalMyProfile.fd-style-compact .modal-box.wide{
     width: 1144px;
-    max-height: calc(100vh - var(--tb-h) - 16px);
+    max-height: var(--fd-compact-h);
 }
 
 #modalFriendDetail.fd-style-compact #friendDetailContent,
 #modalMyProfile.fd-style-compact #myProfileContent{
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
+    height: var(--fd-compact-h);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -338,12 +338,12 @@
 #modalFriendDetail.fd-style-compact #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact #mypTabJson > .json-viewer{
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
+    height: calc(var(--fd-compact-h) - 88px) !important;
     margin: 0 !important;
 }
 #modalFriendDetail.fd-style-compact .fd-modal-bar + .fd-layout #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact .fd-modal-bar + .fd-layout #mypTabJson > .json-viewer{
-    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
+    height: calc(var(--fd-compact-h) - 132px) !important;
 }
 
 #modalFriendDetail.fd-style-compact .fd-info-cols,

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -169,7 +169,7 @@
 #modalFriendDetail.fd-style-compact #friendDetailContent,
 #modalMyProfile.fd-style-compact #myProfileContent{
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 640px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -332,12 +332,12 @@
 #modalFriendDetail.fd-style-compact #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact #mypTabJson > .json-viewer{
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 554px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
     margin: 0 !important;
 }
 #modalFriendDetail.fd-style-compact .fd-modal-bar + .fd-layout #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact .fd-modal-bar + .fd-layout #mypTabJson > .json-viewer{
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 510px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
 }
 
 #modalFriendDetail.fd-style-compact .fd-info-cols,

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -40,7 +40,7 @@
 
 .fd-info-top-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 265px;
+    grid-template-columns: minmax(0, 1fr) 305px;
     gap: 10px;
     align-items: stretch;
 }
@@ -67,7 +67,7 @@
 
 .fd-info-cols {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 265px;
+    grid-template-columns: minmax(0, 1fr) 305px;
     gap: 10px;
     align-items: stretch;
 }
@@ -163,13 +163,19 @@
 
 /*COMPACT MODE — two-column layout with left identity panel*/
 
+#modalFriendDetail.fd-style-compact,
+#modalMyProfile.fd-style-compact{ padding: calc(var(--tb-h) + 8px) 0 8px; }
+
 #modalFriendDetail.fd-style-compact .modal-box.wide,
-#modalMyProfile.fd-style-compact .modal-box.wide{ width: 1040px; }
+#modalMyProfile.fd-style-compact .modal-box.wide{
+    width: 1144px;
+    max-height: calc(100vh - var(--tb-h) - 16px);
+}
 
 #modalFriendDetail.fd-style-compact #friendDetailContent,
 #modalMyProfile.fd-style-compact #myProfileContent{
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -332,17 +338,17 @@
 #modalFriendDetail.fd-style-compact #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact #mypTabJson > .json-viewer{
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
     margin: 0 !important;
 }
 #modalFriendDetail.fd-style-compact .fd-modal-bar + .fd-layout #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact .fd-modal-bar + .fd-layout #mypTabJson > .json-viewer{
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
 }
 
 #modalFriendDetail.fd-style-compact .fd-info-cols,
 #modalMyProfile.fd-style-compact .fd-info-cols{
-    grid-template-columns: minmax(0, 1fr) 212px;
+    grid-template-columns: minmax(0, 1fr) 244px;
 }
 
 #modalFriendDetail.fd-style-compact .fd-info-card .fd-group-card.fd-group-rep,

--- a/frontend/core/modals/user-modal/user-modal.js
+++ b/frontend/core/modals/user-modal/user-modal.js
@@ -1385,7 +1385,7 @@ function drawMiniTimeline(events, el) {
         const dt     = `${fmtShortDate(d)} | ${fmtTime(d)}`;
         const ei     = ev.id.replace(/'/g, "\\'");
         const detail = typeof _tlListData === 'function' ? (_tlListData(ev).detail || '') : '';
-        return `<div style="display:flex;align-items:center;gap:8px;padding:5px 2px;border-bottom:1px solid var(--brd);cursor:pointer;" onclick="openTlDetail('${ei}')">
+        return `<div style="display:flex;align-items:center;gap:8px;padding:5px 2px;border-bottom:1px solid var(--brd);cursor:pointer;" onclick="navOpenModal('tlEvent','${ei}','${jsq(meta.label || '')}')">
             <span style="font-size:11px;color:var(--tx3);white-space:nowrap;">${esc(dt)}</span>
             <span class="msi" style="font-size:14px;color:${color};flex-shrink:0;">${meta.icon}</span>
             <span style="font-size:12px;">${esc(meta.label)}</span>

--- a/frontend/core/modals/user-modal/user-modal.js
+++ b/frontend/core/modals/user-modal/user-modal.js
@@ -383,7 +383,7 @@ function renderUserFavWorlds(payload) {
     groups.forEach((g, i) => {
         const label = esc(g.displayName || g.name);
         const count = g.worlds ? g.worlds.length : 0;
-        pillsHtml += `<button class="fd-tab fd-content-pill${i === activePill ? ' active' : ''}" onclick="switchFavPill(${i},this)">${label} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${count}</span></button>`;
+        pillsHtml += `<button class="fd-tab fd-content-pill${i === activePill ? ' active' : ''}" onclick="switchFavPill(${i},this)">${label} <span class="vrcn-badge fd-tab-badge">${count}</span></button>`;
     });
     pillsHtml += `</div>`;
 
@@ -446,11 +446,11 @@ function renderFdUserAvatars(payload) {
     const avatars = payload.avatars || [];
 
     const avatarsPill = document.getElementById('fdAvatarsPill');
-    if (avatarsPill) avatarsPill.innerHTML = `${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${avatars.length}</span>`;
+    if (avatarsPill) avatarsPill.innerHTML = `${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge fd-tab-badge">${avatars.length}</span>`;
 
     const worldsCount = Array.isArray(currentFriendDetail?.userWorlds) ? currentFriendDetail.userWorlds.length : 0;
     const contentTab = document.getElementById('fdTabContentBtn');
-    if (contentTab) contentTab.innerHTML = `${t('profiles.tabs.content_label', 'Content')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${worldsCount + avatars.length}</span>`;
+    if (contentTab) contentTab.innerHTML = `${t('profiles.tabs.content_label', 'Content')} <span class="vrcn-badge fd-tab-badge">${worldsCount + avatars.length}</span>`;
 
     window._fdAllAvatars = avatars;
     window._fdAvatarsPage = 0;
@@ -875,8 +875,8 @@ function renderFriendDetail(d) {
 
     const mutualsContent = `
         <div class="fd-content-pills">
-            <button class="fd-tab fd-mutual-pill active" onclick="switchFdMutualsPill('friends',this)">${t('profiles.mutuals.pill_friends_label', 'Friends')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allMutuals.length}</span></button>
-            <button class="fd-tab fd-mutual-pill" onclick="switchFdMutualsPill('groups',this)">${t('profiles.mutuals.pill_groups_label', 'Groups')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allMutualGroups.length}</span></button>
+            <button class="fd-tab fd-mutual-pill active" onclick="switchFdMutualsPill('friends',this)">${t('profiles.mutuals.pill_friends_label', 'Friends')} <span class="vrcn-badge fd-tab-badge">${allMutuals.length}</span></button>
+            <button class="fd-tab fd-mutual-pill" onclick="switchFdMutualsPill('groups',this)">${t('profiles.mutuals.pill_groups_label', 'Groups')} <span class="vrcn-badge fd-tab-badge">${allMutualGroups.length}</span></button>
         </div>
         <div id="fdMutualsFriends">${mutualsFriendsHtml}</div>
         <div id="fdMutualsGroups" style="display:none;">${mutualsGroupsHtml}</div>`;
@@ -1030,7 +1030,7 @@ function renderFriendDetail(d) {
     const hasTabs = hasGroups || hasMutuals || hasContent;
     const groupsTabCount = (window._fdAllGroupsAll || allGroups).length;
 
-    const _tabBadge = (n) => `<span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${n}</span>`;
+    const _tabBadge = (n) => `<span class="vrcn-badge fd-tab-badge">${n}</span>`;
     let tabsHtml = '';
     if (hasTabs) {
         tabsHtml = `<div class="fd-tabs"><button class="fd-tab active" data-fdtab="info" onclick="switchFdTab('info',this)">${t('profiles.tabs.info', 'Info')}</button>`;
@@ -1048,8 +1048,8 @@ function renderFriendDetail(d) {
     const userId = d.id || '';
     const contentHtml = `
         <div class="fd-content-pills">
-            <button class="fd-tab fd-content-pill active" id="fdWorldsPill" onclick="switchFdContentPill('worlds',this)">${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allUserWorlds.length}</span></button>
-            <button class="fd-tab fd-content-pill" id="fdAvatarsPill" onclick="switchFdContentPill('avatars',this)">${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">0</span></button>
+            <button class="fd-tab fd-content-pill active" id="fdWorldsPill" onclick="switchFdContentPill('worlds',this)">${t('profiles.content.worlds_pill_label', 'Worlds')} <span class="vrcn-badge fd-tab-badge">${allUserWorlds.length}</span></button>
+            <button class="fd-tab fd-content-pill" id="fdAvatarsPill" onclick="switchFdContentPill('avatars',this)">${t('profiles.content.avatars_pill_label', 'Avatars')} <span class="vrcn-badge fd-tab-badge">0</span></button>
         </div>
         <div id="fdContentWorlds">
             <div id="fdWorldsGrid"></div>

--- a/frontend/core/modals/vrc-tools-modal/vrc-config-modal.html
+++ b/frontend/core/modals/vrc-tools-modal/vrc-config-modal.html
@@ -1,6 +1,9 @@
         <div class="modal-box" style="width:616px;max-width:90%;">
-            <div class="modal-title" style="margin-bottom:4px;" data-i18n="vrc_config.title">VRChat Config</div>
-            <div class="modal-msg" style="margin-bottom:18px;" data-i18n="vrc_config.desc">Edit VRChat's config.json directly. Changes are written to VRChat's own data folder.</div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="vrc_config.title">VRChat Config</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalVrcConfig').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="modal-msg" style="margin:20px 0 18px;" data-i18n="vrc_config.desc">Edit VRChat's config.json directly. Changes are written to VRChat's own data folder.</div>
 
             <!-- Cache row -->
             <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;background:var(--bg-input);border-radius:8px;padding:10px 12px;margin-bottom:18px;">
@@ -23,7 +26,6 @@
             <div class="modal-btns" style="margin-top:22px;justify-content:space-between;">
                 <button class="vrcn-button-round" onclick="sendToCS({action:'openUrl',url:'https://docs.vrchat.com/docs/configuration-file'})"><span class="msi">open_in_new</span> <span data-i18n="vrc_config.docs">VRChat Docs</span></button>
                 <div style="display:flex;gap:8px;">
-                    <button class="vrcn-button-round" onclick="document.getElementById('modalVrcConfig').style.display='none'" data-i18n="common.close">Close</button>
                     <button class="vrcn-button-round vrcn-btn-join" onclick="vrcCfgSave()" data-i18n="common.save">Save</button>
                 </div>
             </div>

--- a/frontend/core/modals/vrc-tools-modal/vrc-launch-options-modal.html
+++ b/frontend/core/modals/vrc-tools-modal/vrc-launch-options-modal.html
@@ -1,6 +1,9 @@
         <div class="modal-box" style="width:616px;max-width:90%;">
-            <div class="modal-title" style="margin-bottom:4px;" data-i18n="vrc_launch.title">VRChat Launch Options</div>
-            <div class="modal-msg" style="margin-bottom:18px;" data-i18n="vrc_launch.desc">Extra arguments passed to VRChat on launch. Optional override path lets you launch a specific VRChat executable instead of going through Steam.</div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="vrc_launch.title">VRChat Launch Options</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalVrcLaunchOptions').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="modal-msg" style="margin:20px 0 18px;" data-i18n="vrc_launch.desc">Extra arguments passed to VRChat on launch. Optional override path lets you launch a specific VRChat executable instead of going through Steam.</div>
 
             <div style="background:var(--bg-input);border-radius:8px;padding:10px 12px;margin-bottom:18px;font-size:11.5px;color:var(--tx3);line-height:1.6;">
                 <div>--fps=144</div>
@@ -22,7 +25,6 @@
             <div class="modal-btns" style="margin-top:22px;justify-content:space-between;">
                 <button class="vrcn-button-round" onclick="sendToCS({action:'openUrl',url:'https://docs.vrchat.com/docs/launch-options'})"><span class="msi">open_in_new</span> <span data-i18n="vrc_launch.docs">VRChat Docs</span></button>
                 <div style="display:flex;gap:8px;">
-                    <button class="vrcn-button-round" onclick="document.getElementById('modalVrcLaunchOptions').style.display='none'" data-i18n="common.close">Close</button>
                     <button class="vrcn-button-round vrcn-btn-join" onclick="vrcLaSave()" data-i18n="common.save">Save</button>
                 </div>
             </div>

--- a/frontend/core/modals/world-modal/world-modal.css
+++ b/frontend/core/modals/world-modal/world-modal.css
@@ -6,13 +6,13 @@
 #modalDetail.wd-style-compact .modal-box,
 #modalDetail.gd-style-compact .modal-box {
     width: 1144px;
-    max-height: calc(100vh - var(--tb-h) - 16px);
+    max-height: var(--fd-compact-h);
 }
 
 #modalDetail.wd-style-compact #detailModalContent,
 #modalDetail.gd-style-compact #detailModalContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
+    height: var(--fd-compact-h);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -118,12 +118,12 @@
 #modalDetail.wd-style-compact #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact #gdTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
+    height: calc(var(--fd-compact-h) - 88px) !important;
     margin: 0 !important;
 }
 #modalDetail.wd-style-compact .fd-modal-bar + .fd-layout #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact .fd-modal-bar + .fd-layout #gdTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
+    height: calc(var(--fd-compact-h) - 132px) !important;
 }
 
 #modalDetail.wd-style-compact #wdTabInstances .wd-instances-list {
@@ -173,11 +173,11 @@
 #modalAvatarDetail.av-style-compact { padding: calc(var(--tb-h) + 8px) 0 8px; }
 #modalAvatarDetail.av-style-compact .modal-box {
     width: 1144px;
-    max-height: calc(100vh - var(--tb-h) - 16px);
+    max-height: var(--fd-compact-h);
 }
 #modalAvatarDetail.av-style-compact #avatarDetailContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
+    height: var(--fd-compact-h);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -258,11 +258,11 @@
 }
 #modalAvatarDetail.av-style-compact #avTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
+    height: calc(var(--fd-compact-h) - 88px) !important;
     margin: 0 !important;
 }
 #modalAvatarDetail.av-style-compact .fd-modal-bar + .fd-layout #avTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
+    height: calc(var(--fd-compact-h) - 132px) !important;
 }
 #modalAvatarDetail.av-style-compact .fd-bio-badges-row {
     flex-wrap: nowrap;

--- a/frontend/core/modals/world-modal/world-modal.css
+++ b/frontend/core/modals/world-modal/world-modal.css
@@ -1,12 +1,18 @@
 /* === World Modal === */
 
+#modalDetail.wd-style-compact,
+#modalDetail.gd-style-compact { padding: calc(var(--tb-h) + 8px) 0 8px; }
+
 #modalDetail.wd-style-compact .modal-box,
-#modalDetail.gd-style-compact .modal-box { width: 1040px; }
+#modalDetail.gd-style-compact .modal-box {
+    width: 1144px;
+    max-height: calc(100vh - var(--tb-h) - 16px);
+}
 
 #modalDetail.wd-style-compact #detailModalContent,
 #modalDetail.gd-style-compact #detailModalContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -112,12 +118,12 @@
 #modalDetail.wd-style-compact #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact #gdTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
     margin: 0 !important;
 }
 #modalDetail.wd-style-compact .fd-modal-bar + .fd-layout #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact .fd-modal-bar + .fd-layout #gdTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
 }
 
 #modalDetail.wd-style-compact #wdTabInstances .wd-instances-list {
@@ -164,10 +170,14 @@
     max-width: 100%;
 }
 
-#modalAvatarDetail.av-style-compact .modal-box { width: 1040px; }
+#modalAvatarDetail.av-style-compact { padding: calc(var(--tb-h) + 8px) 0 8px; }
+#modalAvatarDetail.av-style-compact .modal-box {
+    width: 1144px;
+    max-height: calc(100vh - var(--tb-h) - 16px);
+}
 #modalAvatarDetail.av-style-compact #avatarDetailContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 16px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -248,11 +258,11 @@
 }
 #modalAvatarDetail.av-style-compact #avTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 104px), 618px) !important;
     margin: 0 !important;
 }
 #modalAvatarDetail.av-style-compact .fd-modal-bar + .fd-layout #avTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 148px), 574px) !important;
 }
 #modalAvatarDetail.av-style-compact .fd-bio-badges-row {
     flex-wrap: nowrap;

--- a/frontend/core/modals/world-modal/world-modal.css
+++ b/frontend/core/modals/world-modal/world-modal.css
@@ -6,7 +6,7 @@
 #modalDetail.wd-style-compact #detailModalContent,
 #modalDetail.gd-style-compact #detailModalContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 640px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -112,12 +112,12 @@
 #modalDetail.wd-style-compact #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact #gdTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 554px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
     margin: 0 !important;
 }
 #modalDetail.wd-style-compact .fd-modal-bar + .fd-layout #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact .fd-modal-bar + .fd-layout #gdTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 510px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
 }
 
 #modalDetail.wd-style-compact #wdTabInstances .wd-instances-list {
@@ -167,7 +167,7 @@
 #modalAvatarDetail.av-style-compact .modal-box { width: 1040px; }
 #modalAvatarDetail.av-style-compact #avatarDetailContent {
     padding: 0;
-    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 640px);
+    height: min(calc(100vh - var(--tb-h, 0px) - 80px), 704px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -248,11 +248,11 @@
 }
 #modalAvatarDetail.av-style-compact #avTabJson > .json-viewer {
     max-height: none !important;
-    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 554px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 168px), 618px) !important;
     margin: 0 !important;
 }
 #modalAvatarDetail.av-style-compact .fd-modal-bar + .fd-layout #avTabJson > .json-viewer {
-    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 510px) !important;
+    height: min(calc(100vh - var(--tb-h, 0px) - 212px), 574px) !important;
 }
 #modalAvatarDetail.av-style-compact .fd-bio-badges-row {
     flex-wrap: nowrap;

--- a/frontend/core/modals/world-modal/world-modal.js
+++ b/frontend/core/modals/world-modal/world-modal.js
@@ -412,7 +412,7 @@ function renderWdInstanceHistory(worldId, events) {
         const dt     = `${fmtShortDate(d)} | ${fmtTime(d)}`;
         const ei     = ev.id.replace(/'/g, "\\'");
         const detail = typeof _tlListData === 'function' ? (_tlListData(ev).detail || '') : '';
-        return `<div style="display:flex;align-items:center;gap:8px;padding:5px 2px;border-bottom:1px solid var(--brd);cursor:pointer;" onclick="openTlDetail('${ei}')">
+        return `<div style="display:flex;align-items:center;gap:8px;padding:5px 2px;border-bottom:1px solid var(--brd);cursor:pointer;" onclick="navOpenModal('tlEvent','${ei}','${jsq(meta.label || '')}')">
             <span style="font-size:11px;color:var(--tx3);white-space:nowrap;">${esc(dt)}</span>
             <span class="msi" style="font-size:14px;color:${color};flex-shrink:0;">${meta.icon}</span>
             <span style="font-size:12px;">${esc(meta.label)}</span>

--- a/frontend/core/modals/world-modal/world-modal.js
+++ b/frontend/core/modals/world-modal/world-modal.js
@@ -882,8 +882,8 @@ function openWorldDetail(worldId) {
     const wiBar = renderModalActions([
         canJoin ? { icon: 'login', title: t('dashboard.instances.join_world', 'Join World'), onclick: `worldJoinAction('${loc}')` } : null,
         { icon: 'public', title: t('dashboard.instances.open_world', 'Open World'), onclick: `navOpenModal('worldSearch','${wid}','${esc(cached?.name || '')}')` },
+        { icon: 'close', title: t('common.close', 'Close'), onclick: `closeWorldDetail()` },
     ]);
-    let actionsHtml = `<div class="fd-actions"><button class="vrcn-button-round" style="margin-left:auto;" onclick="closeWorldDetail()">${t('common.close', 'Close')}</button></div>`;
 
     c.innerHTML = `${wiBar}${bannerHtml}<div class="fd-content${thumb ? ' fd-has-banner' : ''}" style="padding:16px 0;">
         <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(worldName)}</h2>
@@ -892,7 +892,7 @@ function openWorldDetail(worldId) {
             const _ob = getOwnerBadgeHtml(_oid, myInst?.ownerName || '', myInst?.ownerGroup || '', 'closeWorldDetail()');
             return `<span class="vrcn-badge ${instClass}">${instLabel}</span>${singleRegionBadge}${_ob}${singleInstCopy}`;
         })()}</div>
-        ${friendsHtml}${actionsHtml}</div>`;
+        ${friendsHtml}</div>`;
     if (thumb) { const s = document.getElementById('wi-banner-slot'); const bi = _getWorldBannerImg(worldId, thumb); if (s && bi) s.insertBefore(bi, s.firstChild); }
     m.style.display = 'flex';
 }

--- a/frontend/core/modals/world-modal/world-modal.js
+++ b/frontend/core/modals/world-modal/world-modal.js
@@ -135,9 +135,9 @@ function _wdUpdateInstancesInPlace(w) {
 
     // Update count label and tab button
     const countSpan = tab.querySelector('.wd-section-label span');
-    if (countSpan) countSpan.innerHTML = `${t('worlds.instances.active_title_label', 'ACTIVE INSTANCES')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allInstances.length}</span>`;
+    if (countSpan) countSpan.innerHTML = `${t('worlds.instances.active_title_label', 'ACTIVE INSTANCES')} <span class="vrcn-badge fd-tab-badge">${allInstances.length}</span>`;
     const tabBtn = [...document.querySelectorAll('.fd-tab')].find(b => b.getAttribute('onclick') && b.getAttribute('onclick').includes("'instances'"));
-    if (tabBtn) tabBtn.innerHTML = `${t('worlds.tabs.instances_label', 'Instances')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allInstances.length}</span>`;
+    if (tabBtn) tabBtn.innerHTML = `${t('worlds.tabs.instances_label', 'Instances')} <span class="vrcn-badge fd-tab-badge">${allInstances.length}</span>`;
 }
 
 function renderWorldSearchDetail(w) {
@@ -243,7 +243,7 @@ function renderWorldSearchDetail(w) {
 
     const tabsHtml = `<div class="fd-tabs" style="margin-bottom:14px;">
         <button class="fd-tab active" onclick="switchWdTab('info',this)">${t('worlds.tabs.info', 'Info')}</button>
-        <button class="fd-tab" onclick="switchWdTab('instances',this)">${t('worlds.tabs.instances_label', 'Instances')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allInstances.length}</span></button>
+        <button class="fd-tab" onclick="switchWdTab('instances',this)">${t('worlds.tabs.instances_label', 'Instances')} <span class="vrcn-badge fd-tab-badge">${allInstances.length}</span></button>
         ${hasWorldPhotos ? `<button class="fd-tab" onclick="switchWdTab('photos',this)">${t('worlds.tabs.photos', 'Photos')}</button>` : ''}
         ${isOwnWorld ? `<button class="fd-tab" onclick="switchWdTab('insights',this)">${t('worlds.tabs.insights', 'Insights')}</button>` : ''}
         <button class="fd-tab" onclick="switchWdTab('json',this)">Json</button>
@@ -318,7 +318,7 @@ function renderWorldSearchDetail(w) {
     const wdInfoCompactRight = `<div class="fd-info-wrap">${wdDescCardCompact}${wdComPopRow}<div class="fd-info-card">${wdHistoryInner}</div></div>`;
 
     const wdInstancesTab = `<div id="wdTabInstances" style="display:none;">
-            <div class="wd-section-label wd-instances-label" style="margin-top:4px;"><span>${t('worlds.instances.active_title_label', 'ACTIVE INSTANCES')} <span class="vrcn-badge" style="background:var(--accent);color:#fff;font-size:10px;padding:1px 5px;margin-left:4px;">${allInstances.length}</span></span><button class="mi-refresh-btn" id="wdInstancesRefreshBtn" onclick="refreshWorldInstances()" title="Refresh instances">&#8635;</button></div>
+            <div class="wd-section-label wd-instances-label" style="margin-top:4px;"><span>${t('worlds.instances.active_title_label', 'ACTIVE INSTANCES')} <span class="vrcn-badge fd-tab-badge">${allInstances.length}</span></span><button class="mi-refresh-btn" id="wdInstancesRefreshBtn" onclick="refreshWorldInstances()" title="Refresh instances">&#8635;</button></div>
             ${instancesHtml}
         </div>`;
     const wdPhotosTab = `<div id="wdTabPhotos" style="display:none;"><div id="wdPhotosGrid"></div><div id="wdPhotosPaginatorBar" class="mini-paginator"></div></div>`;

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -2798,6 +2798,8 @@
   "settings.decorations.profile_theme_desc": "Wenn aktiviert, werden die VRC+ Theme-Farben eines Spielers auf sein Profil-Modal angewendet. Die Button-Farbe färbt auch das Modal selbst, etwa 25% dunkler.",
   "settings.decorations.theme_vrcn_override": "VRCN+ Farben bevorzugen",
   "settings.decorations.theme_vrcn_override_desc": "Wenn aktiviert, haben VRCN+ Profilfarben Vorrang vor dem VRC+ Profil-Theme eines Spielers.",
+  "settings.decorations.theme_contrast": "Theme-Text lesbar halten",
+  "settings.decorations.theme_contrast_desc": "Wenn aktiviert, werden Text und Icons eines VRC+ Profil-Themes nur so weit abgedunkelt oder aufgehellt, dass sie auf dem Hintergrund des Themes lesbar bleiben. Deaktiviere dies, um die unveränderten Theme-Farben zu sehen.",
   "profiles.theme.title": "Profil-Theme",
   "profiles.theme.add": "Neues Theme",
   "profiles.theme.edit": "Theme bearbeiten",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1421,6 +1421,7 @@
   "library.detail.favorited": "Favorisiert",
   "library.detail.prev": "Zurück",
   "library.detail.next": "Weiter",
+  "library.detail.click_to_reveal": "Zum Anzeigen klicken",
   "library.detail.zoom_in": "Vergrößern",
   "library.detail.zoom_out": "Verkleinern",
   "library.detail.rotate_left": "Links drehen",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1875,6 +1875,7 @@
   "groups.roles.create_role": "Rolle erstellen",
   "groups.roles.empty": "Keine Rollen gefunden",
   "groups.roles.show": "Rollen anzeigen",
+  "groups.roles.yours": "Deine Rolle",
   "groups.roles.no_permissions": "Diese Rolle hat keine Berechtigungen.",
   "groups.roles.meta.all": "alle",
   "groups.roles.meta.permission_one": "Berechtigung",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1874,6 +1874,8 @@
   "groups.roles.name_placeholder": "Rollenname...",
   "groups.roles.create_role": "Rolle erstellen",
   "groups.roles.empty": "Keine Rollen gefunden",
+  "groups.roles.show": "Rollen anzeigen",
+  "groups.roles.no_permissions": "Diese Rolle hat keine Berechtigungen.",
   "groups.roles.meta.all": "alle",
   "groups.roles.meta.permission_one": "Berechtigung",
   "groups.roles.meta.permission_other": "Berechtigungen",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1467,6 +1467,7 @@
   "library.detail.favorited": "Favorited",
   "library.detail.prev": "Previous",
   "library.detail.next": "Next",
+  "library.detail.click_to_reveal": "Click to reveal",
   "library.detail.zoom_in": "Zoom In",
   "library.detail.zoom_out": "Zoom Out",
   "library.detail.rotate_left": "Rotate Left",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1915,6 +1915,8 @@
   "groups.roles.name_placeholder": "Role name...",
   "groups.roles.create_role": "Create Role",
   "groups.roles.empty": "No roles found",
+  "groups.roles.show": "Show Roles",
+  "groups.roles.no_permissions": "This role has no permissions.",
   "groups.roles.meta.all": "all",
   "groups.roles.meta.permission_one": "permission",
   "groups.roles.meta.permission_other": "permissions",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -2839,6 +2839,8 @@
   "settings.decorations.profile_theme_desc": "When enabled, a player's VRC+ profile theme colours are applied to their profile modal. The button colour also tints the modal itself, about 25% darker.",
   "settings.decorations.theme_vrcn_override": "Prefer VRCN+ Colours",
   "settings.decorations.theme_vrcn_override_desc": "When enabled, VRCN+ profile colours take precedence over a player's VRC+ profile theme.",
+  "settings.decorations.theme_contrast": "Keep Theme Text Readable",
+  "settings.decorations.theme_contrast_desc": "When enabled, text and icons of a VRC+ profile theme are darkened or lightened just enough to stay readable on the theme's own background. Turn this off to show the raw theme colours.",
   "profiles.theme.title": "Profile Theme",
   "profiles.theme.add": "New Theme",
   "profiles.theme.edit": "Edit Theme",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1916,6 +1916,7 @@
   "groups.roles.create_role": "Create Role",
   "groups.roles.empty": "No roles found",
   "groups.roles.show": "Show Roles",
+  "groups.roles.yours": "Your role",
   "groups.roles.no_permissions": "This role has no permissions.",
   "groups.roles.meta.all": "all",
   "groups.roles.meta.permission_one": "permission",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1871,6 +1871,7 @@
   "groups.roles.create_role": "Crear rol",
   "groups.roles.empty": "No se encontraron roles",
   "groups.roles.show": "Mostrar roles",
+  "groups.roles.yours": "Tu rol",
   "groups.roles.no_permissions": "Este rol no tiene permisos.",
   "groups.roles.meta.all": "todos",
   "groups.roles.meta.permission_one": "permiso",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1417,6 +1417,7 @@
   "library.detail.favorited": "Favorito",
   "library.detail.prev": "Anterior",
   "library.detail.next": "Siguiente",
+  "library.detail.click_to_reveal": "Haz clic para mostrar",
   "library.detail.zoom_in": "Acercar",
   "library.detail.zoom_out": "Alejar",
   "library.detail.rotate_left": "Girar a la izquierda",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1870,6 +1870,8 @@
   "groups.roles.name_placeholder": "Nombre del rol...",
   "groups.roles.create_role": "Crear rol",
   "groups.roles.empty": "No se encontraron roles",
+  "groups.roles.show": "Mostrar roles",
+  "groups.roles.no_permissions": "Este rol no tiene permisos.",
   "groups.roles.meta.all": "todos",
   "groups.roles.meta.permission_one": "permiso",
   "groups.roles.meta.permission_other": "permisos",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -2794,6 +2794,8 @@
   "settings.decorations.profile_theme_desc": "Cuando está activado, los colores del tema VRC+ de un jugador se aplican a su modal de perfil. El color del botón también tiñe el modal, un 25% más oscuro.",
   "settings.decorations.theme_vrcn_override": "Preferir colores VRCN+",
   "settings.decorations.theme_vrcn_override_desc": "Cuando está activado, los colores VRCN+ tienen prioridad sobre el tema de perfil VRC+ del jugador.",
+  "settings.decorations.theme_contrast": "Mantener legible el texto del tema",
+  "settings.decorations.theme_contrast_desc": "Cuando está activado, el texto y los iconos de un tema de perfil VRC+ se oscurecen o aclaran lo justo para seguir siendo legibles sobre el fondo del propio tema. Desactívalo para ver los colores originales del tema.",
   "profiles.theme.title": "Tema de perfil",
   "profiles.theme.add": "Nuevo tema",
   "profiles.theme.edit": "Editar tema",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1871,6 +1871,7 @@
   "groups.roles.create_role": "Créer le rôle",
   "groups.roles.empty": "Aucun rôle trouvé",
   "groups.roles.show": "Afficher les rôles",
+  "groups.roles.yours": "Votre rôle",
   "groups.roles.no_permissions": "Ce rôle n’a aucune permission.",
   "groups.roles.meta.all": "toutes",
   "groups.roles.meta.permission_one": "permission",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1417,6 +1417,7 @@
   "library.detail.favorited": "Favori",
   "library.detail.prev": "Précédent",
   "library.detail.next": "Suivant",
+  "library.detail.click_to_reveal": "Cliquer pour afficher",
   "library.detail.zoom_in": "Zoom avant",
   "library.detail.zoom_out": "Zoom arrière",
   "library.detail.rotate_left": "Rotation gauche",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1870,6 +1870,8 @@
   "groups.roles.name_placeholder": "Nom du rôle...",
   "groups.roles.create_role": "Créer le rôle",
   "groups.roles.empty": "Aucun rôle trouvé",
+  "groups.roles.show": "Afficher les rôles",
+  "groups.roles.no_permissions": "Ce rôle n’a aucune permission.",
   "groups.roles.meta.all": "toutes",
   "groups.roles.meta.permission_one": "permission",
   "groups.roles.meta.permission_other": "permissions",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -2794,6 +2794,8 @@
   "settings.decorations.profile_theme_desc": "Lorsque cette option est activée, les couleurs du thème VRC+ d'un joueur sont appliquées à sa fenêtre de profil. La couleur du bouton teinte aussi la fenêtre, environ 25% plus sombre.",
   "settings.decorations.theme_vrcn_override": "Préférer les couleurs VRCN+",
   "settings.decorations.theme_vrcn_override_desc": "Lorsque cette option est activée, les couleurs VRCN+ priment sur le thème de profil VRC+ du joueur.",
+  "settings.decorations.theme_contrast": "Garder le texte du thème lisible",
+  "settings.decorations.theme_contrast_desc": "Lorsque cette option est activée, le texte et les icônes d'un thème de profil VRC+ sont assombris ou éclaircis juste assez pour rester lisibles sur le fond du thème. Désactivez-la pour afficher les couleurs d'origine du thème.",
   "profiles.theme.title": "Thème de profil",
   "profiles.theme.add": "Nouveau thème",
   "profiles.theme.edit": "Modifier le thème",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -2793,6 +2793,8 @@
   "settings.decorations.profile_theme_desc": "有効にすると、プレイヤーのVRC+テーマの色がプロフィールに適用されます。ボタンの色はモーダル自体も約25%暗く染めます。",
   "settings.decorations.theme_vrcn_override": "VRCN+の色を優先",
   "settings.decorations.theme_vrcn_override_desc": "有効にすると、VRCN+のプロフィール色がVRC+テーマより優先されます。",
+  "settings.decorations.theme_contrast": "テーマの文字を読みやすく保つ",
+  "settings.decorations.theme_contrast_desc": "有効にすると、VRC+プロフィールテーマの文字とアイコンが、テーマの背景上で読みやすくなる分だけ暗く、または明るく調整されます。オフにすると、テーマ本来の色が表示されます。",
   "profiles.theme.title": "プロフィールテーマ",
   "profiles.theme.add": "新しいテーマ",
   "profiles.theme.edit": "テーマを編集",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -1869,6 +1869,8 @@
   "groups.roles.name_placeholder": "ロール名...",
   "groups.roles.create_role": "ロールを作成",
   "groups.roles.empty": "ロールが見つかりません",
+  "groups.roles.show": "ロールを表示",
+  "groups.roles.no_permissions": "このロールには権限がありません。",
   "groups.roles.meta.all": "すべて",
   "groups.roles.meta.permission_one": "権限",
   "groups.roles.meta.permission_other": "権限",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -1870,6 +1870,7 @@
   "groups.roles.create_role": "ロールを作成",
   "groups.roles.empty": "ロールが見つかりません",
   "groups.roles.show": "ロールを表示",
+  "groups.roles.yours": "あなたのロール",
   "groups.roles.no_permissions": "このロールには権限がありません。",
   "groups.roles.meta.all": "すべて",
   "groups.roles.meta.permission_one": "権限",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -1417,6 +1417,7 @@
   "library.detail.favorited": "お気に入り",
   "library.detail.prev": "前へ",
   "library.detail.next": "次へ",
+  "library.detail.click_to_reveal": "クリックして表示",
   "library.detail.zoom_in": "拡大",
   "library.detail.zoom_out": "縮小",
   "library.detail.rotate_left": "左回転",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -2462,6 +2462,7 @@
   "library.detail.favorited": "В избранном",
   "library.detail.prev": "Назад",
   "library.detail.next": "Вперёд",
+  "library.detail.click_to_reveal": "Нажмите, чтобы показать",
   "library.detail.zoom_in": "Приблизить",
   "library.detail.zoom_out": "Отдалить",
   "library.detail.rotate_left": "Повернуть влево",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -1855,6 +1855,8 @@
   "groups.roles.name_placeholder": "Название роли...",
   "groups.roles.create_role": "Создать роль",
   "groups.roles.empty": "Нет ролей",
+  "groups.roles.show": "Показать роли",
+  "groups.roles.no_permissions": "У этой роли нет разрешений.",
   "groups.roles.meta.all": "Все",
   "groups.roles.meta.permission_one": "разрешение",
   "groups.roles.meta.permission_other": "разрешений",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -1856,6 +1856,7 @@
   "groups.roles.create_role": "Создать роль",
   "groups.roles.empty": "Нет ролей",
   "groups.roles.show": "Показать роли",
+  "groups.roles.yours": "Ваша роль",
   "groups.roles.no_permissions": "У этой роли нет разрешений.",
   "groups.roles.meta.all": "Все",
   "groups.roles.meta.permission_one": "разрешение",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -2818,6 +2818,8 @@
   "settings.decorations.profile_theme_desc": "Если включено, цвета VRC+ темы игрока применяются к его профилю. Цвет кнопки также тонирует окно, примерно на 25% темнее.",
   "settings.decorations.theme_vrcn_override": "Предпочитать цвета VRCN+",
   "settings.decorations.theme_vrcn_override_desc": "Если включено, цвета VRCN+ имеют приоритет над темой профиля VRC+.",
+  "settings.decorations.theme_contrast": "Сохранять читаемость текста темы",
+  "settings.decorations.theme_contrast_desc": "Если включено, текст и значки темы профиля VRC+ затемняются или осветляются ровно настолько, чтобы оставаться читаемыми на фоне самой темы. Отключите, чтобы видеть исходные цвета темы.",
   "profiles.theme.title": "Тема профиля",
   "profiles.theme.add": "Новая тема",
   "profiles.theme.edit": "Изменить тему",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -2794,6 +2794,8 @@
   "settings.decorations.profile_theme_desc": "启用后，玩家的 VRC+ 主题颜色会应用到其个人资料窗口。按钮颜色也会为窗口着色，约暗 25%。",
   "settings.decorations.theme_vrcn_override": "优先使用 VRCN+ 颜色",
   "settings.decorations.theme_vrcn_override_desc": "启用后，VRCN+ 颜色优先于玩家的 VRC+ 主题。",
+  "settings.decorations.theme_contrast": "保持主题文字可读",
+  "settings.decorations.theme_contrast_desc": "启用后，VRC+ 个人主页主题的文字和图标会被适度调暗或调亮，以便在主题背景上保持可读。关闭后将显示主题的原始颜色。",
   "profiles.theme.title": "个人资料主题",
   "profiles.theme.add": "新建主题",
   "profiles.theme.edit": "编辑主题",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -1871,6 +1871,7 @@
   "groups.roles.create_role": "创建角色",
   "groups.roles.empty": "未找到角色",
   "groups.roles.show": "显示身份组",
+  "groups.roles.yours": "你的身份组",
   "groups.roles.no_permissions": "此身份组没有任何权限。",
   "groups.roles.meta.all": "全部",
   "groups.roles.meta.permission_one": "项权限",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -1870,6 +1870,8 @@
   "groups.roles.name_placeholder": "角色名称...",
   "groups.roles.create_role": "创建角色",
   "groups.roles.empty": "未找到角色",
+  "groups.roles.show": "显示身份组",
+  "groups.roles.no_permissions": "此身份组没有任何权限。",
   "groups.roles.meta.all": "全部",
   "groups.roles.meta.permission_one": "项权限",
   "groups.roles.meta.permission_other": "项权限",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -1417,6 +1417,7 @@
   "library.detail.favorited": "已收藏",
   "library.detail.prev": "上一个",
   "library.detail.next": "下一个",
+  "library.detail.click_to_reveal": "点击显示",
   "library.detail.zoom_in": "放大",
   "library.detail.zoom_out": "缩小",
   "library.detail.rotate_left": "向左旋转",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -519,10 +519,12 @@
     <!-- News Article Modal -->
     <div class="modal-overlay" id="modalNewsArticle" style="display:none;" onclick="if(event.target===this)this.style.display='none'">
         <div class="modal-box" style="width:720px;max-width:94%;display:flex;flex-direction:column;max-height:86vh;">
-            <div class="modal-title" id="newsArticleTitle" style="margin-bottom:12px;">News</div>
-            <div id="newsArticleBody" class="news-article-body" onclick="newsArticleLinkClick(event)" style="flex:1;overflow-y:auto;min-height:0;"></div>
-            <div class="modal-btns" style="margin-top:16px;justify-content:space-between;">
-                <button class="vrcn-button-round" onclick="document.getElementById('modalNewsArticle').style.display='none'" data-i18n="common.close">Close</button>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" id="newsArticleTitle">News</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalNewsArticle').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div id="newsArticleBody" class="news-article-body" onclick="newsArticleLinkClick(event)" style="flex:1;overflow-y:auto;min-height:0;margin-top:20px;"></div>
+            <div class="modal-btns" style="margin-top:16px;">
                 <button class="vrcn-button" onclick="if(_newsArticleLink)sendToCS({action:'openUrl',url:_newsArticleLink})"><span class="msi" style="font-size:14px;">open_in_new</span> <span data-i18n="dashboard.news.full_article">Full Article</span></button>
             </div>
         </div>
@@ -587,8 +589,11 @@
     <!-- Nav Editor Modal -->
     <div class="modal-overlay" id="navEditorOverlay" style="display:none;align-items:center;justify-content:center;" onclick="if(event.target===this)closeNavEditor()">
         <div class="modal-box wide narrow">
-            <div class="modal-title" data-i18n="nav.editor.title">Edit Navigation</div>
-            <div id="navEditorList" class="ne-list vrcn-scrollbar"></div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="nav.editor.title">Edit Navigation</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="closeNavEditor()"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div id="navEditorList" class="ne-list vrcn-scrollbar" style="margin-top:20px;"></div>
             <div style="display:flex;gap:8px;align-items:center;">
                 <button class="vrcn-button" onclick="_edAddFolder()"><span class="msi" style="font-size:16px;">create_new_folder</span><span data-i18n="nav.editor.add_folder">Add Folder</span></button>
                 <span style="flex:1;"></span>
@@ -601,13 +606,15 @@
     <!-- Crash Report Modal -->
     <div class="modal-overlay" id="modalCrash" style="display:none;">
         <div class="modal-box" style="width:750px;max-width:90%;">
-            <div class="modal-icon" style="background:rgba(224,108,117,.12);color:var(--err);"><span class="msi" style="font-size:22px;">bug_report</span></div>
-            <div class="modal-title" data-i18n="crash.modal.title">VRCNext has crashed</div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="crash.modal.title">VRCNext has crashed</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalCrash').style.display='none';sendToCS({action:'dismissCrashReport'})"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="modal-icon" style="background:rgba(224,108,117,.12);color:var(--err);margin-top:20px;"><span class="msi" style="font-size:22px;">bug_report</span></div>
             <div class="modal-msg" data-i18n="crash.modal.msg">Would you like to send the crash report to the developers to help them fix the issue? The crash log is anonymous and only contains the stack trace of the crash. It does not include any personal information or user data.</div>
             <div class="log-area" id="crashLogPreview" style="max-height:200px;margin:14px 0 4px;font-size:10.5px;"></div>
-            <div class="modal-btns" style="justify-content:space-between;">
+            <div class="modal-btns">
                 <button class="vrcn-button-round vrcn-btn-join" onclick="document.getElementById('modalCrash').style.display='none';sendToCS({action:'sendCrashReport'})" data-i18n="crash.modal.send">Send Report</button>
-                <button class="vrcn-button-round" onclick="document.getElementById('modalCrash').style.display='none';sendToCS({action:'dismissCrashReport'})" data-i18n="common.close">Close</button>
             </div>
         </div>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -123,7 +123,7 @@
     </div>
     <div class="app-body">
     <div class="sidebar" id="sidebarEl">
-        <div class="logo"><div class="logo-icon" id="logoIcon">V</div><div class="logo-txt"><div class="logo-text-row"><div class="logo-text">VRCNext</div></div><div class="logo-sub">v2026.35.2</div></div></div>
+        <div class="logo"><div class="logo-icon" id="logoIcon">V</div><div class="logo-txt"><div class="logo-text-row"><div class="logo-text">VRCNext</div></div><div class="logo-sub">v2026.35.3</div></div></div>
         <div class="nav vrcn-scrollbar" id="navEl"></div>
         <div class="clock-area"><div class="clock-time" id="clock">00:00:00</div><div class="clock-date" id="clockDate"></div></div>
         <div class="play-area"><button class="btn-play" onclick="playVRChat()"><span class="msi play-icon">play_arrow</span><span class="pl" data-i18n="sidebar.play_vrchat">Play VRChat</span></button></div>
@@ -531,15 +531,15 @@
     <!-- Export Modal -->
     <div class="modal-overlay" id="modalExport" style="display:none;" onclick="if(event.target===this)this.style.display='none'">
         <div class="modal-box" style="width:640px;max-width:92%;">
-            <div class="modal-title" id="exportTitle" style="margin-bottom:4px;">Export</div>
-            <div class="modal-msg" id="exportDesc" style="margin-bottom:14px;"></div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" id="exportTitle">Export</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalExport').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div class="modal-msg" id="exportDesc" style="margin:20px 0 14px;"></div>
             <textarea id="exportText" readonly spellcheck="false" style="width:100%;height:320px;box-sizing:border-box;resize:vertical;background:var(--bg-input);color:var(--tx1);border:1px solid var(--brd-lt);border-radius:8px;padding:10px 12px;font-family:monospace;font-size:12px;line-height:1.5;white-space:pre;overflow:auto;"></textarea>
-            <div class="modal-btns" style="margin-top:16px;justify-content:space-between;">
-                <button class="vrcn-button-round" onclick="document.getElementById('modalExport').style.display='none'" data-i18n="common.close">Close</button>
-                <div style="display:flex;gap:8px;">
-                    <button class="vrcn-button-round" onclick="exportCopy()"><span class="msi" style="font-size:14px;">content_copy</span> <span data-i18n="export.copy">Copy</span></button>
-                    <button class="vrcn-button-round vrcn-btn-join" onclick="exportSaveCsv()"><span class="msi" style="font-size:14px;">download</span> <span data-i18n="export.export_csv">Export CSV</span></button>
-                </div>
+            <div class="modal-btns" style="margin-top:16px;">
+                <button class="vrcn-button-round" onclick="exportCopy()"><span class="msi" style="font-size:14px;">content_copy</span> <span data-i18n="export.copy">Copy</span></button>
+                <button class="vrcn-button-round vrcn-btn-join" onclick="exportSaveCsv()"><span class="msi" style="font-size:14px;">download</span> <span data-i18n="export.export_csv">Export CSV</span></button>
             </div>
         </div>
     </div>

--- a/frontend/modules/dashboard/dash-layout.html
+++ b/frontend/modules/dashboard/dash-layout.html
@@ -1,10 +1,12 @@
         <div class="modal-box wide narrow">
-            <div class="modal-title" data-i18n="dashboard.edit.title">Dashboard Layout</div>
-            <div id="dashLayoutList" class="ne-list vrcn-scrollbar"></div>
+            <div class="fd-modal-bar">
+                <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="dashboard.edit.title">Dashboard Layout</span></div>
+                <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="closeDashLayoutEditor()"><span class="msi" style="font-size:20px;">close</span></button></div>
+            </div>
+            <div id="dashLayoutList" class="ne-list vrcn-scrollbar" style="margin-top:20px;"></div>
             <div style="display:flex;gap:8px;align-items:center;">
                 <button class="vrcn-button" onclick="dashLayoutReset()"><span class="msi" style="font-size:16px;">restart_alt</span><span data-i18n="dashboard.edit.reset">Reset</span></button>
                 <span style="flex:1;"></span>
-                <button class="vrcn-button" onclick="closeDashLayoutEditor()"><span data-i18n="common.cancel">Cancel</span></button>
                 <button class="vrcn-button vrcn-btn-primary" onclick="saveDashLayoutFromModal()"><span class="msi" style="font-size:16px;">check</span><span data-i18n="common.save">Save</span></button>
             </div>
         </div>

--- a/frontend/modules/inventory/inventory.js
+++ b/frontend/modules/inventory/inventory.js
@@ -385,10 +385,10 @@ function showInvDeleteModal(type, id, versionId, name) {
     overlay.style.display = 'flex'; // inline display required by _closeTopModal (Escape)
     overlay.id = 'invDeleteModal';
     overlay.onclick = event => { if (event.target === overlay) closeInvDeleteModal(); };
-    overlay.innerHTML = `<div class="modal-box"><div class="modal-icon danger"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-title">${esc(t('inventory.modal.delete_title', 'Delete Item'))}</div><div class="modal-msg">${esc(t('inventory.modal.delete_message', 'Permanently delete from VRChat:'))}<br><span class="modal-fname">${esc(name)}</span><br><span style="font-size:11px;color:var(--tx3);">${esc(t('inventory.modal.delete_irreversible', 'This cannot be undone.'))}</span></div><div class="modal-btns"><button id="invDelCancelBtn" class="vrcn-button-round" onclick="closeInvDeleteModal()">${esc(t('common.cancel', 'Cancel'))}</button><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmInvDelete()">${esc(t('inventory.actions.delete', 'Delete'))}</button></div></div>`;
+    overlay.innerHTML = `<div class="modal-box">${renderModalBar(t('inventory.modal.delete_title', 'Delete Item'), [modalCloseAction('closeInvDeleteModal()')])}<div class="modal-icon danger" style="margin-top:20px;"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-msg">${esc(t('inventory.modal.delete_message', 'Permanently delete from VRChat:'))}<br><span class="modal-fname">${esc(name)}</span><br><span style="font-size:11px;color:var(--tx3);">${esc(t('inventory.modal.delete_irreversible', 'This cannot be undone.'))}</span></div><div class="modal-btns"><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmInvDelete()">${esc(t('inventory.actions.delete', 'Delete'))}</button></div></div>`;
     document.body.appendChild(overlay);
 
-    overlay.querySelector('#invDelCancelBtn').focus();
+    overlay.querySelector('.fd-modal-bar-actions .fd-action-btn')?.focus();
 
     const handler = event => {
         if (event.key === 'Escape') {

--- a/frontend/modules/inventory/inventory_upload.js
+++ b/frontend/modules/inventory/inventory_upload.js
@@ -239,10 +239,8 @@ function _iuBuildHTML(tab) {
         </div>` : '';
 
     return `<div class="modal-box wide" id="invUploadContent" style="max-width:560px;">
-        <div style="margin-bottom:14px;">
-            <div style="font-size:16px;font-weight:700;color:var(--tx0);">${esc(tf('inventory.upload.title', { tab: tabLabel }, `Upload to ${tabLabel}`))}</div>
-        </div>
-        <div style="background:var(--bg-input);border-radius:8px;padding:10px 14px;margin-bottom:14px;font-size:12px;color:var(--tx2);">${esc(req?.hint || '')}</div>
+        ${renderModalBar(tf('inventory.upload.title', { tab: tabLabel }, `Upload to ${tabLabel}`), [modalCloseAction('closeInvUploadModal()')])}
+        <div style="background:var(--bg-input);border-radius:8px;padding:10px 14px;margin:20px 0 14px;font-size:12px;color:var(--tx2);">${esc(req?.hint || '')}</div>
         <div id="iuDropZone" class="iu-dropzone"
             onclick="iuBrowse()"
             ondragover="event.preventDefault();this.classList.add('dragover')"
@@ -258,7 +256,6 @@ function _iuBuildHTML(tab) {
         ${emojiHtml}
         <div id="iuError" style="display:none;margin-top:10px;padding:10px 14px;background:rgba(220,50,50,.12);border-radius:8px;font-size:12px;color:#e05252;"></div>
         <div style="display:flex;gap:8px;margin-top:16px;justify-content:flex-end;">
-            <button class="vrcn-button-round" onclick="closeInvUploadModal()">${esc(t('common.cancel', 'Cancel'))}</button>
             <button class="vrcn-button-round vrcn-btn-join" id="iuUploadBtn" style="display:none;" onclick="iuDoUpload()">${iuUploadButtonHtml()}</button>
         </div>
     </div>`;

--- a/frontend/modules/media-library/library.js
+++ b/frontend/modules/media-library/library.js
@@ -894,7 +894,7 @@ function cacheVidThumb(v, fp) {
 
 // Photo detail modal — image on the left, info card on the right.
 // Accepts: number (libraryFiles index), string (file path → looked up in libraryFiles), or item object.
-const _photoState = { scale: 1, rotation: 0, tx: 0, ty: 0, item: null, drag: null, revealed: false, shownPath: '' };
+const _photoState = { scale: 1, rotation: 0, tx: 0, ty: 0, item: null, drag: null, revealed: false, shownPath: '', navOwned: false };
 let _photoKeyHandler = null;
 const _photoNavCache = {};
 
@@ -915,6 +915,7 @@ function openPhotoDetail(target) {
     _photoState.drag = null;
     _photoState.revealed = false;
 
+    _photoState.navOwned = !!x.path;
     if (x.path && typeof navSetCurrent === 'function') {
         navSetCurrent('photo', x.path);
         if (typeof navUpdateLabel === 'function') navUpdateLabel(x.name || '');
@@ -991,7 +992,10 @@ function _photoCreateModal(x) {
 function _photoRenderContent(modal, x) {
     const isVid = x.type === 'video';
     const box = modal.querySelector('.photo-detail-box');
-    if (box) box.classList.toggle('pd-is-video', isVid);
+    if (box) {
+        box.classList.toggle('pd-is-video', isVid);
+        box.classList.toggle('pd-no-info', !!x.remote);
+    }
 
     const barTitle = modal.querySelector('.fd-modal-bar-title');
     if (barTitle) {
@@ -1061,7 +1065,7 @@ function _photoRenderContent(modal, x) {
     if (oldToolbar) oldToolbar.outerHTML = _photoBuildToolbar(x);
 
     const infoPane = modal.querySelector('.photo-detail-info-pane');
-    if (infoPane) infoPane.innerHTML = _photoBuildInfoPaneContent(x);
+    if (infoPane) infoPane.innerHTML = x.remote ? '' : _photoBuildInfoPaneContent(x);
 }
 
 function _photoBuildVideoControls() {
@@ -1130,17 +1134,27 @@ function _photoBuildToolbar(x) {
     const prevDisabled = (navIdx <= 0)                              ? ' disabled' : '';
     const nextDisabled = (navIdx < 0 || navIdx >= navList.length-1) ? ' disabled' : '';
 
+    const navBtns = x.remote
+        ? { prev: '', next: '' }
+        : {
+            prev: `<button class="pdt-btn" onclick="photoNavPrev()" title="${esc(t('library.detail.prev', 'Previous'))}"${prevDisabled}><span class="msi">chevron_left</span></button><span class="pdt-sep"></span>`,
+            next: `<span class="pdt-sep"></span><button class="pdt-btn" onclick="photoNavNext()" title="${esc(t('library.detail.next', 'Next'))}"${nextDisabled}><span class="msi">chevron_right</span></button>`,
+        };
+
+    const copyBtns = x.remote
+        ? `<button class="pdt-btn" onclick="photoDownload()" title="${esc(t('context_menu.image.download', 'Download Image'))}"><span class="msi">download</span></button>
+           <button class="pdt-btn" onclick="photoCopyLink()" title="${esc(t('common.share', 'Share'))}"><span class="msi">link</span></button>`
+        : `<button class="pdt-btn" onclick="photoCopy()" title="${esc(t('library.actions.copy_clipboard', 'Copy to clipboard'))}"><span class="msi">content_copy</span></button>`;
+
     return `<div class="photo-detail-toolbar" onmousedown="event.stopPropagation()">
-        <button class="pdt-btn" onclick="photoNavPrev()" title="${esc(t('library.detail.prev', 'Previous'))}"${prevDisabled}><span class="msi">chevron_left</span></button>
-        <span class="pdt-sep"></span>
-        <button class="pdt-btn" onclick="photoCopy()" title="${esc(t('library.actions.copy_clipboard', 'Copy to clipboard'))}"><span class="msi">content_copy</span></button>
+        ${navBtns.prev}
+        ${copyBtns}
         <button class="pdt-btn" onclick="photoZoom(1.25)" title="${esc(t('library.detail.zoom_in', 'Zoom In'))}"><span class="msi">zoom_in</span></button>
         <button class="pdt-btn" onclick="photoZoom(0.8)" title="${esc(t('library.detail.zoom_out', 'Zoom Out'))}"><span class="msi">zoom_out</span></button>
         <button class="pdt-btn" onclick="photoRotate(-90)" title="${esc(t('library.detail.rotate_left', 'Rotate Left'))}"><span class="msi">rotate_left</span></button>
         <button class="pdt-btn" onclick="photoRotate(90)" title="${esc(t('library.detail.rotate_right', 'Rotate Right'))}"><span class="msi">rotate_right</span></button>
         <button class="pdt-btn" onclick="photoReset()" title="${esc(t('library.detail.reset', 'Reset'))}"><span class="msi">refresh</span></button>
-        <span class="pdt-sep"></span>
-        <button class="pdt-btn" onclick="photoNavNext()" title="${esc(t('library.detail.next', 'Next'))}"${nextDisabled}><span class="msi">chevron_right</span></button>
+        ${navBtns.next}
     </div>`;
 }
 
@@ -1212,8 +1226,9 @@ function _photoBuildInfoPaneContent(x) {
 }
 
 function closePhotoDetail(fromNav = false) {
+    const clearNav = !fromNav && _photoState.navOwned && typeof navClear === 'function';
     const m = document.getElementById('photoDetailModal');
-    if (!m) { if (!fromNav && typeof navClear === 'function') navClear(); return; }
+    if (!m) { if (clearNav) navClear(); return; }
     if (_photoKeyHandler) { document.removeEventListener('keydown', _photoKeyHandler); _photoKeyHandler = null; }
     document.removeEventListener('mousemove', _photoOnMouseMove);
     document.removeEventListener('mouseup',   _photoOnMouseUp);
@@ -1223,7 +1238,8 @@ function closePhotoDetail(fromNav = false) {
     m.querySelectorAll('img').forEach(img => { img.src = PLACEHOLDER; });
     m.remove();
     _photoState.shownPath = '';
-    if (!fromNav && typeof navClear === 'function') navClear();
+    _photoState.navOwned = false;
+    if (clearNav) navClear();
 }
 
 // === Photo modal interactions ===
@@ -1256,6 +1272,22 @@ function photoCopy() {
     const it = _photoState.item;
     if (!it || !it.path) return;
     copyToClipboard(it.url || '', it.path, it.type || 'image');
+}
+
+function photoDownload() {
+    const it = _photoState.item;
+    if (!it || !it.url) return;
+    const guess = (it.url.split('?')[0].split('/').pop() || '').trim();
+    const fileName = /\.[a-z0-9]{3,4}$/i.test(guess) ? guess : 'image.png';
+    sendToCS({ action: 'invDownload', url: it.url, fileName });
+}
+
+function photoCopyLink() {
+    const it = _photoState.item;
+    if (!it || !it.url) return;
+    navigator.clipboard.writeText(it.url)
+        .then(() => showToast(true, t('common.link_copied', 'Link copied!')))
+        .catch(() => {});
 }
 
 function photoNavPrev() { _photoNav(-1); }
@@ -1344,32 +1376,20 @@ function _photoOnMouseUp() {
     document.removeEventListener('mouseup',   _photoOnMouseUp);
 }
 
-// Lightbox.
-function openLightbox(u, t) {
-    const lb    = document.createElement('div');
-    lb.className = 'lib-lightbox';
-    const closeLb = () => {
-        // Clear src BEFORE removing element to release decoded bitmaps
-        lb.querySelectorAll('img').forEach(img => { img.src = PLACEHOLDER; });
-        lb.querySelectorAll('video').forEach(v => { try { v.pause(); } catch {} v.src = ''; });
-        lb.remove();
-        document.removeEventListener('keydown', ok);
-    };
-    lb.onclick = e => { if (e.target === lb) closeLb(); };
-    if (t === 'video') {
-        const v    = document.createElement('video');
-        v.src      = u;
-        v.controls = true;
-        v.autoplay = true;
-        v.style.cssText = 'max-width:90%;max-height:90%;border-radius:8px;';
-        v.onclick  = e => e.stopPropagation();
-        lb.appendChild(v);
-    } else {
-        lb.innerHTML = `<img src="${u}">`;
-    }
-    document.body.appendChild(lb);
-    const ok = e => { if (e.key === 'Escape') closeLb(); };
-    document.addEventListener('keydown', ok);
+// Lightbox — reuses the photo modal without the info sidebar.
+function openLightbox(u, kind) {
+    if (!u) return;
+    openPhotoDetail({
+        name:     '',
+        path:     '',
+        url:      u,
+        type:     kind === 'video' ? 'video' : 'image',
+        modified: Date.now(),
+        size:     '',
+        players:  [],
+        imgW: 0, imgH: 0,
+        remote:   true,
+    });
 }
 
 // Delete modal.

--- a/frontend/modules/media-library/library.js
+++ b/frontend/modules/media-library/library.js
@@ -921,14 +921,16 @@ function _photoCreateModal(x) {
     o.id        = 'photoDetailModal';
     o.onclick   = e => { if (e.target === o) closePhotoDetail(); };
     o.innerHTML = `<div class="photo-detail-box">
-        <div class="fd-modal-actions"><button class="btn-notif fd-action-btn" onclick="closePhotoDetail()" title="${esc(t('common.close', 'Close'))}"><span class="msi" style="font-size:20px;">close</span></button></div>
-        <div class="photo-detail-img-pane">
-            <img class="photo-detail-img" alt="" draggable="false" style="display:none;" onerror="this.style.display='none'">
-            <video class="photo-detail-video" playsinline style="display:none;"></video>
-            <div class="pd-video-controls-mount"></div>
-            <div class="photo-detail-toolbar-mount"></div>
+        ${renderModalBar(x?.name || t('timeline.photo', 'Photo'), [modalCloseAction('closePhotoDetail()')], { flush: true })}
+        <div class="photo-detail-panes">
+            <div class="photo-detail-img-pane">
+                <img class="photo-detail-img" alt="" draggable="false" style="display:none;" onerror="this.style.display='none'">
+                <video class="photo-detail-video" playsinline style="display:none;"></video>
+                <div class="pd-video-controls-mount"></div>
+                <div class="photo-detail-toolbar-mount"></div>
+            </div>
+            <div class="photo-detail-info-pane"></div>
         </div>
-        <div class="photo-detail-info-pane"></div>
     </div>`;
     document.body.appendChild(o);
 
@@ -953,6 +955,13 @@ function _photoRenderContent(modal, x) {
     const isVid = x.type === 'video';
     const box = modal.querySelector('.photo-detail-box');
     if (box) box.classList.toggle('pd-is-video', isVid);
+
+    const barTitle = modal.querySelector('.fd-modal-bar-title');
+    if (barTitle) {
+        const label = x.name || t('timeline.photo', 'Photo');
+        barTitle.textContent = label;
+        barTitle.title = label;
+    }
 
     const imgPane = modal.querySelector('.photo-detail-img-pane');
     if (imgPane) {

--- a/frontend/modules/media-library/library.js
+++ b/frontend/modules/media-library/library.js
@@ -843,6 +843,11 @@ function toggleHidden(p) {
     filterLibrary(true); // stay on current page
     renderDashRecentPhotos();
     if (typeof _wdRenderPhotosPage === 'function') _wdRenderPhotosPage();
+    const photoModal = document.getElementById('photoDetailModal');
+    if (photoModal && _photoState.item?.path === p) {
+        _photoState.revealed = false;
+        _photoApplyBlur(photoModal, _photoState.item);
+    }
 }
 
 async function setLibItemAsDashBg(path, url) {
@@ -889,15 +894,18 @@ function cacheVidThumb(v, fp) {
 
 // Photo detail modal — image on the left, info card on the right.
 // Accepts: number (libraryFiles index), string (file path → looked up in libraryFiles), or item object.
-const _photoState = { scale: 1, rotation: 0, tx: 0, ty: 0, item: null, drag: null };
+const _photoState = { scale: 1, rotation: 0, tx: 0, ty: 0, item: null, drag: null, revealed: false, shownPath: '' };
 let _photoKeyHandler = null;
+const _photoNavCache = {};
 
 function openPhotoDetail(target) {
     let x;
     if (typeof target === 'number')      x = libraryFiles[target];
-    else if (typeof target === 'string') x = libraryFiles.find(f => f.path === target);
+    else if (typeof target === 'string') x = libraryFiles.find(f => f.path === target) || _photoNavCache[target];
     else                                  x = target;
     if (!x) return;
+
+    if (x.path) _photoNavCache[x.path] = x;
 
     _photoState.item = x;
     _photoState.scale = 1;
@@ -905,6 +913,12 @@ function openPhotoDetail(target) {
     _photoState.tx = 0;
     _photoState.ty = 0;
     _photoState.drag = null;
+    _photoState.revealed = false;
+
+    if (x.path && typeof navSetCurrent === 'function') {
+        navSetCurrent('photo', x.path);
+        if (typeof navUpdateLabel === 'function') navUpdateLabel(x.name || '');
+    }
 
     const existing = document.getElementById('photoDetailModal');
     if (existing) {
@@ -913,6 +927,27 @@ function openPhotoDetail(target) {
     } else {
         _photoCreateModal(x);
     }
+}
+
+function _photoIsBlurred(x) {
+    return !_photoState.revealed
+        && !!(x && x.path)
+        && typeof hiddenMedia !== 'undefined'
+        && hiddenMedia.has(x.path);
+}
+
+function _photoRevealClick(e) {
+    if (e.target.closest('.photo-detail-toolbar, .pd-video-controls-mount')) return;
+    if (!_photoIsBlurred(_photoState.item)) return;
+    e.stopPropagation();
+    _photoState.revealed = true;
+    const modal = document.getElementById('photoDetailModal');
+    if (modal) _photoApplyBlur(modal, _photoState.item);
+}
+
+function _photoApplyBlur(modal, x) {
+    const pane = modal.querySelector('.photo-detail-img-pane');
+    if (pane) pane.classList.toggle('pd-blurred', _photoIsBlurred(x));
 }
 
 function _photoCreateModal(x) {
@@ -926,6 +961,7 @@ function _photoCreateModal(x) {
             <div class="photo-detail-img-pane">
                 <img class="photo-detail-img" alt="" draggable="false" style="display:none;" onerror="this.style.display='none'">
                 <video class="photo-detail-video" playsinline style="display:none;"></video>
+                <div class="pd-blur-hint"><span class="msi">visibility_off</span><span>${esc(t('library.detail.click_to_reveal', 'Click to reveal'))}</span></div>
                 <div class="pd-video-controls-mount"></div>
                 <div class="photo-detail-toolbar-mount"></div>
             </div>
@@ -940,6 +976,7 @@ function _photoCreateModal(x) {
     if (imgPane) {
         imgPane.addEventListener('wheel',     _photoOnWheel, { passive: false });
         imgPane.addEventListener('mousedown', _photoOnMouseDown);
+        imgPane.addEventListener('click',     _photoRevealClick);
     }
 
     const ok = e => {
@@ -962,6 +999,21 @@ function _photoRenderContent(modal, x) {
         barTitle.textContent = label;
         barTitle.title = label;
     }
+
+    const prevPath = _photoState.shownPath || '';
+    if (prevPath && prevPath !== x.path && typeof hiddenMedia !== 'undefined' && hiddenMedia.has(prevPath)) {
+        const oldImg = modal.querySelector('.photo-detail-img');
+        const oldVid = modal.querySelector('.photo-detail-video');
+        if (oldImg) oldImg.src = PLACEHOLDER;
+        if (oldVid) {
+            try { oldVid.pause(); } catch {}
+            oldVid.removeAttribute('src');
+            try { oldVid.load(); } catch {}
+        }
+    }
+    _photoState.shownPath = x.path || '';
+
+    _photoApplyBlur(modal, x);
 
     const imgPane = modal.querySelector('.photo-detail-img-pane');
     if (imgPane) {
@@ -1105,7 +1157,7 @@ function _photoBuildInfoPaneContent(x) {
         ? (resTag ? `${resTag} (${x.imgW}×${x.imgH})` : `${x.imgW}×${x.imgH}`)
         : resTag;
 
-    const worldRowClick = worldId ? ` onclick="closePhotoDetail();openWorldSearchDetail('${esc(worldId)}')"` : '';
+    const worldRowClick = worldId ? ` onclick="navOpenModal('worldSearch','${jsq(worldId)}','${jsq(worldName || '')}')"` : '';
     const worldCursor   = worldId ? 'cursor:pointer;' : '';
     const isFav = x.path && (typeof favorites !== 'undefined') && favorites.has(x.path);
     const favBadge = `<span class="vrcn-badge accent"><span class="msi" style="font-size:11px;">star</span>${esc(t('library.detail.favorited', 'Favorited'))}</span>`;
@@ -1116,7 +1168,7 @@ function _photoBuildInfoPaneContent(x) {
     if (authorName) {
         const authorLabel = esc(t('library.detail.author', 'Author'));
         if (authorId) {
-            authorRow = `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;cursor:pointer;" onclick="closePhotoDetail();openFriendDetail('${jsq(authorId)}')"><span style="color:var(--tx3);">${authorLabel}</span><span style="color:var(--accent-lt);font-weight:700;text-align:right;">${esc(authorName)}</span></div>`;
+            authorRow = `<div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;font-size:11px;cursor:pointer;" onclick="navOpenModal('friend','${jsq(authorId)}','${jsq(authorName)}')"><span style="color:var(--tx3);">${authorLabel}</span><span style="color:var(--accent-lt);font-weight:700;text-align:right;">${esc(authorName)}</span></div>`;
         } else {
             authorRow = _tlMr(authorLabel, `<span style="font-weight:700;">${esc(authorName)}</span>`);
         }
@@ -1144,7 +1196,7 @@ function _photoBuildInfoPaneContent(x) {
                 ? `<div class="tl-player-card-av" style="background-image:url('${cssUrl(image)}')"></div>`
                 : `<div class="tl-player-card-av">${esc(name[0].toUpperCase())}</div>`;
             const badge   = live ? `<span class="vrcn-badge bdg-friend"><span class="msi" style="font-size:10px;">check_circle</span>${t('profiles.badges.friend', 'Friend')}</span>` : '';
-            const onclick = p.userId ? `onclick="closePhotoDetail();openFriendDetail('${jsq(p.userId)}')"` : '';
+            const onclick = p.userId ? `onclick="navOpenModal('friend','${jsq(p.userId)}','${jsq(name)}')"` : '';
             const clickCls = p.userId ? ' clickable' : '';
             grid += `<div class="tl-player-card${clickCls}" ${onclick}>${av}<div class="tl-player-card-info"><div class="tl-player-card-name"><span>${esc(name)}</span>${badge}</div></div></div>`;
         });
@@ -1159,9 +1211,9 @@ function _photoBuildInfoPaneContent(x) {
         ${playersHtml}`;
 }
 
-function closePhotoDetail() {
+function closePhotoDetail(fromNav = false) {
     const m = document.getElementById('photoDetailModal');
-    if (!m) return;
+    if (!m) { if (!fromNav && typeof navClear === 'function') navClear(); return; }
     if (_photoKeyHandler) { document.removeEventListener('keydown', _photoKeyHandler); _photoKeyHandler = null; }
     document.removeEventListener('mousemove', _photoOnMouseMove);
     document.removeEventListener('mouseup',   _photoOnMouseUp);
@@ -1170,6 +1222,8 @@ function closePhotoDetail() {
     if (vid) { try { vid.pause(); } catch {} if (vid._pdCleanup) vid._pdCleanup(); vid.removeAttribute('src'); }
     m.querySelectorAll('img').forEach(img => { img.src = PLACEHOLDER; });
     m.remove();
+    _photoState.shownPath = '';
+    if (!fromNav && typeof navClear === 'function') navClear();
 }
 
 // === Photo modal interactions ===

--- a/frontend/modules/media-library/library.js
+++ b/frontend/modules/media-library/library.js
@@ -763,9 +763,9 @@ function libEditDeleteSelected() {
     o.style.display = 'flex'; // inline display required by _closeTopModal (Escape)
     o.id        = 'deleteModal';
     o.onclick   = e => { if (e.target === o) closeDeleteModal(); };
-    o.innerHTML = `<div class="modal-box"><div class="modal-icon danger"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-title">${t('library.delete.title', 'Delete File')}</div><div class="modal-msg">${tf('library.edit.delete_confirm', { count }, 'Permanently delete {count} file(s) from disk?')}</div><div class="modal-btns"><button id="libDelCancelBtn" class="vrcn-button-round" onclick="closeDeleteModal()">${t('common.cancel', 'Cancel')}</button><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmLibEditDelete()">${t('library.delete.confirm', 'Delete')}</button></div></div>`;
+    o.innerHTML = `<div class="modal-box">${renderModalBar(t('library.delete.title', 'Delete File'), [modalCloseAction('closeDeleteModal()')])}<div class="modal-icon danger" style="margin-top:20px;"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-msg">${tf('library.edit.delete_confirm', { count }, 'Permanently delete {count} file(s) from disk?')}</div><div class="modal-btns"><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmLibEditDelete()">${t('library.delete.confirm', 'Delete')}</button></div></div>`;
     document.body.appendChild(o);
-    o.querySelector('#libDelCancelBtn')?.focus();
+    o.querySelector('.fd-modal-bar-actions .fd-action-btn')?.focus();
 }
 
 function confirmLibEditDelete() {
@@ -1319,9 +1319,9 @@ function showDeleteModal(fp, fn) {
     o.style.display = 'flex'; // inline display required by _closeTopModal (Escape)
     o.id        = 'deleteModal';
     o.onclick   = e => { if (e.target === o) closeDeleteModal(); };
-    o.innerHTML = `<div class="modal-box"><div class="modal-icon danger"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-title">${t('library.delete.title', 'Delete File')}</div><div class="modal-msg">${t('library.delete.message', 'Permanently delete from disk:')}<br><span class="modal-fname">${esc(fn)}</span></div><div class="modal-btns"><button id="libDelCancelBtn" class="vrcn-button-round" onclick="closeDeleteModal()">${t('common.cancel', 'Cancel')}</button><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmDelete()">${t('library.delete.confirm', 'Delete')}</button></div></div>`;
+    o.innerHTML = `<div class="modal-box">${renderModalBar(t('library.delete.title', 'Delete File'), [modalCloseAction('closeDeleteModal()')])}<div class="modal-icon danger" style="margin-top:20px;"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-msg">${t('library.delete.message', 'Permanently delete from disk:')}<br><span class="modal-fname">${esc(fn)}</span></div><div class="modal-btns"><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmDelete()">${t('library.delete.confirm', 'Delete')}</button></div></div>`;
     document.body.appendChild(o);
-    o.querySelector('#libDelCancelBtn').focus();
+    o.querySelector('.fd-modal-bar-actions .fd-action-btn')?.focus();
     const ok = e => {
         if (e.key === 'Escape') { closeDeleteModal(); document.removeEventListener('keydown', ok); }
         if (e.key === 'Enter')  { confirmDelete();    document.removeEventListener('keydown', ok); }
@@ -1352,7 +1352,7 @@ function showDeleteAllModal() {
     o.style.display = 'flex'; // inline display required by _closeTopModal (Escape)
     o.id        = 'deleteModal';
     o.onclick   = e => { if (e.target === o) closeDeleteModal(); };
-    o.innerHTML = `<div class="modal-box"><div class="modal-icon danger"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-title">${t('library.delete_all.title', 'Delete All Posts')}</div><div class="modal-msg">${tf('library.delete_all.message', { count: postedFiles.length }, 'Delete all {count} post(s) from Discord?')}</div><div class="modal-btns"><button class="vrcn-button-round" onclick="closeDeleteModal()">${t('common.cancel', 'Cancel')}</button><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmDeleteAll()">${t('library.delete_all.confirm', 'Delete All')}</button></div></div>`;
+    o.innerHTML = `<div class="modal-box">${renderModalBar(t('library.delete_all.title', 'Delete All Posts'), [modalCloseAction('closeDeleteModal()')])}<div class="modal-icon danger" style="margin-top:20px;"><span class="msi" style="font-size:22px;">delete</span></div><div class="modal-msg">${tf('library.delete_all.message', { count: postedFiles.length }, 'Delete all {count} post(s) from Discord?')}</div><div class="modal-btns"><button class="vrcn-button-round vrcn-btn-danger" onclick="confirmDeleteAll()">${t('library.delete_all.confirm', 'Delete All')}</button></div></div>`;
     document.body.appendChild(o);
 }
 

--- a/frontend/modules/media-library/media-library.css
+++ b/frontend/modules/media-library/media-library.css
@@ -398,8 +398,16 @@
     box-shadow: 0 20px 60px rgba(0,0,0,.5);
     animation: modalPop .10s ease forwards;
     display: flex;
+    flex-direction: column;
     overflow: hidden;
     position: relative;
+}
+
+.photo-detail-panes {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    overflow: hidden;
 }
 
 .photo-detail-img-pane {
@@ -651,9 +659,8 @@
 }
 
 @media (max-width: 900px) {
-    .photo-detail-box {
+    .photo-detail-panes {
         flex-direction: column;
-        height: min(900px, calc(100vh - var(--tb-h) - 40px));
     }
     .photo-detail-info-pane {
         width: 100%;

--- a/frontend/modules/media-library/media-library.css
+++ b/frontend/modules/media-library/media-library.css
@@ -617,6 +617,8 @@
 }
 .pd-video-controls input[type=range]::-webkit-slider-thumb:hover { transform: scale(1.18); }
 
+.photo-detail-box.pd-no-info .photo-detail-info-pane { display: none; }
+
 .photo-detail-info-pane {
     width: 340px;
     flex-shrink: 0;

--- a/frontend/modules/media-library/media-library.css
+++ b/frontend/modules/media-library/media-library.css
@@ -427,6 +427,37 @@
     cursor: grabbing;
 }
 
+.photo-detail-img,
+.photo-detail-video { transition: filter .18s; }
+
+.photo-detail-img-pane.pd-blurred .photo-detail-img,
+.photo-detail-img-pane.pd-blurred .photo-detail-video {
+    filter: blur(34px);
+    transition: none;
+}
+
+.photo-detail-img-pane.pd-blurred { cursor: pointer; }
+
+.pd-blur-hint {
+    display: none;
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: rgba(255,255,255,.82);
+    font-size: 12px;
+    font-weight: 600;
+    text-shadow: 0 1px 6px rgba(0,0,0,.7);
+    pointer-events: none;
+}
+
+.pd-blur-hint .msi { font-size: 34px; }
+
+.photo-detail-img-pane.pd-blurred .pd-blur-hint { display: flex; }
+
 .photo-detail-img-pane img {
     max-width: 100%;
     max-height: 100%;

--- a/frontend/modules/settings/accounts.js
+++ b/frontend/modules/settings/accounts.js
@@ -110,11 +110,13 @@ function showSwitchAccountModal(username, accountId) {
         modal.addEventListener('click', e => { if (e.target === modal) modal.style.display = 'none'; });
         modal.innerHTML = `
             <div class="modal-box" style="max-width:460px;">
-                <div class="modal-icon" style="background:rgba(56,132,255,.1);color:var(--accent);"><span class="msi" style="font-size:22px;">swap_horiz</span></div>
-                <div class="modal-title" data-i18n="settings.accounts.switch_title">Switch Account</div>
+                <div class="fd-modal-bar">
+                    <div class="fd-modal-bar-crumbs"><span class="fd-modal-bar-title" data-i18n="settings.accounts.switch_title">Switch Account</span></div>
+                    <div class="fd-modal-bar-actions"><button class="btn-notif fd-action-btn" title="Close" data-i18n-title="common.close" onclick="document.getElementById('modalSwitchAccount').style.display='none'"><span class="msi" style="font-size:20px;">close</span></button></div>
+                </div>
+                <div class="modal-icon" style="background:rgba(56,132,255,.1);color:var(--accent);margin-top:20px;"><span class="msi" style="font-size:22px;">swap_horiz</span></div>
                 <div class="modal-msg" id="modalSwitchAccountMsg" style="word-break:normal;overflow-wrap:break-word;line-height:1.5;"></div>
                 <div class="modal-btns">
-                    <button class="vrcn-button-round" onclick="document.getElementById('modalSwitchAccount').style.display='none'" data-i18n="common.cancel">Cancel</button>
                     <button class="vrcn-button-round vrcn-btn-join" id="modalSwitchAccountConfirm" data-i18n="settings.accounts.switch_title">Switch Account</button>
                 </div>
             </div>`;

--- a/frontend/modules/settings/settings.html
+++ b/frontend/modules/settings/settings.html
@@ -296,6 +296,14 @@
                         </div>
                         <div class="set-desc" data-i18n="settings.decorations.theme_vrcn_override_desc">When enabled, VRCN+ profile colours take precedence over a player's VRC+ profile theme.</div>
                         <div class="sf-toggle-row" style="margin-top:14px;">
+                            <span data-i18n="settings.decorations.theme_contrast">Keep Theme Text Readable</span>
+                            <label class="toggle">
+                                <input type="checkbox" id="setProfileThemeContrast" onchange="settings.profileThemeContrast=this.checked;autoSave();if(typeof applyDecorationsSetting==='function')applyDecorationsSetting();">
+                                <div class="toggle-track"><div class="toggle-knob"></div></div>
+                            </label>
+                        </div>
+                        <div class="set-desc" data-i18n="settings.decorations.theme_contrast_desc">When enabled, text and icons of a VRC+ profile theme are darkened or lightened just enough to stay readable on the theme's own background. Turn this off to show the raw theme colours.</div>
+                        <div class="sf-toggle-row" style="margin-top:14px;">
                             <span data-i18n="settings.decorations.transparent_cards">Transparent Profile Cards</span>
                             <label class="toggle">
                                 <input type="checkbox" id="setTransparentProfileCards" onchange="settings.transparentProfileCards=this.checked;autoSave();if(typeof applyDecorationsSetting==='function')applyDecorationsSetting();">

--- a/frontend/modules/settings/settings.js
+++ b/frontend/modules/settings/settings.js
@@ -127,6 +127,7 @@ function saveSettings() {
             enableProfileBackgrounds: document.getElementById('setEnableProfileBg')?.checked ?? false,
             enableProfileThemes: document.getElementById('setEnableProfileThemes')?.checked ?? false,
             profileThemeVrcnOverride: document.getElementById('setThemeVrcnOverride')?.checked ?? false,
+            profileThemeContrast: document.getElementById('setProfileThemeContrast')?.checked ?? true,
             transparentProfileCards: document.getElementById('setTransparentProfileCards')?.checked ?? false,
             showDecorationsOnDashboard: document.getElementById('setDecoOnDashboard')?.checked ?? false,
             profileModalStyle: settings.profileModalStyle || 'classic',
@@ -430,6 +431,9 @@ function loadSettingsToUI(s) {
     settings.profileThemeVrcnOverride = s.ProfileThemeVrcnOverride ?? s.profileThemeVrcnOverride ?? false;
     const _ptoEl = document.getElementById('setThemeVrcnOverride');
     if (_ptoEl) _ptoEl.checked = settings.profileThemeVrcnOverride;
+    settings.profileThemeContrast = s.ProfileThemeContrast ?? s.profileThemeContrast ?? true;
+    const _ptcEl = document.getElementById('setProfileThemeContrast');
+    if (_ptcEl) _ptcEl.checked = settings.profileThemeContrast;
     settings.transparentProfileCards = s.TransparentProfileCards ?? s.transparentProfileCards ?? false;
     const _tpcEl = document.getElementById('setTransparentProfileCards');
     if (_tpcEl) _tpcEl.checked = settings.transparentProfileCards;

--- a/frontend/modules/timeline/timeline.css
+++ b/frontend/modules/timeline/timeline.css
@@ -64,6 +64,12 @@
     gap: 5px;
     width: 135px;
     font-weight: 600;
+    overflow: hidden;
+}
+.tl-list-type > span:not(.tl-list-icon) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
 }
 .tl-list-icon {
     font-size: 15px !important;

--- a/main/AppInfo.cs
+++ b/main/AppInfo.cs
@@ -2,7 +2,7 @@
 
 public static class AppInfo
 {
-    public const string Version = "2026.35.2";
+    public const string Version = "2026.35.3";
     public const string ContactEmail = "vrcn@shinyflvres.com";
     public const string Website = "vrcn.shinyflvres.com";
     public const string UserAgent = $"VRCNext/{Version} ({ContactEmail})";

--- a/main/AuthController.cs
+++ b/main/AuthController.cs
@@ -1795,6 +1795,7 @@ public class AuthController
             _core.Settings.EnableProfileBackgrounds = data["enableProfileBackgrounds"]?.Value<bool>() ?? false;
             _core.Settings.EnableProfileThemes = data["enableProfileThemes"]?.Value<bool>() ?? false;
             _core.Settings.ProfileThemeVrcnOverride = data["profileThemeVrcnOverride"]?.Value<bool>() ?? false;
+            _core.Settings.ProfileThemeContrast = data["profileThemeContrast"]?.Value<bool>() ?? true;
             _core.Settings.TransparentProfileCards = data["transparentProfileCards"]?.Value<bool>() ?? false;
             _core.Settings.ShowDecorationsOnDashboard = data["showDecorationsOnDashboard"]?.Value<bool>() ?? false;
             _core.Settings.ProfileModalStyle = data["profileModalStyle"]?.ToString() ?? "classic";

--- a/main/GroupsController.cs
+++ b/main/GroupsController.cs
@@ -393,6 +393,7 @@ public class GroupsController
                                 isJoined = g["myMember"] != null && g["myMember"].Type != JTokenType.Null,
                                 canPost, canEvent, canEdit, canInvite, canKick, canBan, canManageRoles, canAssignRoles,
                                 canViewAudit,
+                                myRoleIds = (myMember?["roleIds"] as JArray)?.Select(x => x.ToString()).ToArray() ?? Array.Empty<string>(),
                                 roles = (g["roles"] as JArray ?? new JArray()).Select(r => {
                                     var rPerms = (r["permissions"] as JArray)?.Select(p => p.ToString()).ToArray() ?? Array.Empty<string>();
                                     _core.SendToJS("log", new { msg = $"[ROLE] \"{r["name"]}\" perms: [{string.Join(", ", rPerms)}]", color = "sec" });


### PR DESCRIPTION
**2026.35.4**

**Group Modal**
* See roles of group even if you aren't have permissions.

**VRC+ Decoration Improvements**
* Added an option to improve readability on profiles with bad text colors.
* Navbar badges do use icon color now on vrc+ decorated profiles.

**Photo Modal**
* Hidden or blurred images now remain blurred when opened, preventing accidental clicks and photo leaks. Click the image again to reveal it.
* Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.
* All images that can be inspected in any modal do use now the photo modal so you can resize, zoom-in/out/rotate and download the image and have a better "inspecting" experience.

**Timeline**
* Photo, Instance and Location modals do support breadcrumb navigation.

**Design Refactor**
* All modals now use the new header menu with action buttons, matching the design of the updated profile modals.
* Avatar, Profile, Group, and World modals are now slightly taller and wider to display more content.
* Refactored the **Timeline > Friends > Location** modal to match the design of the **Personal Instances** modal.

**Bug Fixes**
* Fixed the **Close**, **Customize Profile**, and **Change Banner** buttons appearing inside your own profile modal instead of in the taskbar when **Use Direct Modal Navigation** is disabled.
* Fixed Log "Type" text being to long in gorup logs.
