### PR TITLE
2026.35.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,9 @@
 **Improvements**
 
 * The tab bar in Profile, World, Group and Avatar modals now stays fixed while the content below it scrolls.
+* Timeline list columns in Personal, Friends and Game Log can now be sorted by clicking a header and reordered by dragging the handle on the right. Sorting covers the whole history, not just the visible page, and your layout is remembered per list.
 
 **Bug Fixes**
 
+* Fixed the column headers in timeline lists not lining up with the content below them.
 * Fixed copying an image from the photo modal putting a local cache link on the clipboard instead of the image itself. The image is now copied and can be pasted directly into Discord, chats or an image editor.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 * The list is now slightly more compact and easier to navigate.
 * Added World description to player list modal.
 * Added World Creator to player list
+* Playerlist can be now sorted with all cell filters.
 
 **Quality-of-Life Updates**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 * Added World description to player list modal.
 * Added World Creator to player list
 * Playerlist can be now sorted with all cell filters.
+* Added Hide/SHow World Panel to player list.
 
 **Quality-of-Life Updates**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,5 @@
-**2026.35.4**
-
-**Group Modal**
-* See roles of group even if you aren't have permissions.
-
-**VRC+ Decoration Improvements**
-* Added an option to improve readability on profiles with bad text colors.
-* Navbar badges do use icon color now on vrc+ decorated profiles.
-
-**Photo Modal**
-* Hidden or blurred images now remain blurred when opened, preventing accidental clicks and photo leaks. Click the image again to reveal it.
-* Photo modals now support breadcrumb navigation. When opening a user profile from a photo, you can navigate back to the photo modal.
-* All images that can be inspected in any modal do use now the photo modal so you can resize, zoom-in/out/rotate and download the image and have a better "inspecting" experience.
-
-**Timeline**
-* Photo, Instance and Location modals do support breadcrumb navigation.
-
-**Design Refactor**
-* All modals now use the new header menu with action buttons, matching the design of the updated profile modals.
-* Avatar, Profile, Group, and World modals are now slightly taller and wider to display more content.
-* Refactored the **Timeline > Friends > Location** modal to match the design of the **Personal Instances** modal.
+**2026.35.6**
 
 **Bug Fixes**
-* Fixed the **Close**, **Customize Profile**, and **Change Banner** buttons appearing inside your own profile modal instead of in the taskbar when **Use Direct Modal Navigation** is disabled.
-* Fixed Log "Type" text being to long in gorup logs.
+
+* Fixed copying an image from the photo modal putting a local cache link on the clipboard instead of the image itself. The image is now copied and can be pasted directly into Discord, chats or an image editor.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 **2026.35.6**
 
+**Improvements**
+
+* The tab bar in Profile, World, Group and Avatar modals now stays fixed while the content below it scrolls.
+
 **Bug Fixes**
 
 * Fixed copying an image from the photo modal putting a local cache link on the clipboard instead of the image itself. The image is now copied and can be pasted directly into Discord, chats or an image editor.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,10 +2,12 @@
 
 **Improvements**
 
-* The tab bar in Profile, World, Group and Avatar modals now stays fixed while the content below it scrolls.
-* Timeline list columns in Personal, Friends and Game Log can now be sorted by clicking a header and reordered by dragging the handle on the right. Sorting covers the whole history, not just the visible page, and your layout is remembered per list.
+* The tab bar in Profile, World, Group, and Avatar modals now stays fixed while the content below it scrolls.
+* Columns in the Timeline’s Personal, Friends, and Game Log lists can now be sorted by clicking their headers and reordered by dragging the handle on the right.
+* Sorting applies to the entire history, not just the currently visible page, and the column layout is remembered separately for each list.
 
 **Bug Fixes**
 
-* Fixed the column headers in timeline lists not lining up with the content below them.
-* Fixed copying an image from the photo modal putting a local cache link on the clipboard instead of the image itself. The image is now copied and can be pasted directly into Discord, chats or an image editor.
+* Fixed column headers in Timeline lists not aligning with the content below them.
+* Fixed copying images from the Photo Modal placing a local cache link on the clipboard instead of the actual image. Images can now be pasted directly into Discord, chats, or image editors.
+* Fixed the heatmap in user profiles using the button color instead of the VRC+ icon color.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,26 @@
 **2026.35.6**
 
+**Player List**
+
+* Updated the Instance Player List to use the new VRCN v2 design.
+* The list is now slightly more compact and easier to navigate.
+* Added World description to player list modal.
+* Added World Creator to player list
+
+**Quality-of-Life Updates**
+
+* Added **Copy Theme** to the **Show More** menu on user profiles. This copies the profile’s colors and applies them to your own profile.
+
 **Improvements**
 
 * The tab bar in Profile, World, Group, and Avatar modals now stays fixed while the content below it scrolls.
 * Columns in the Timeline’s Personal, Friends, and Game Log lists can now be sorted by clicking their headers and reordered by dragging the handle on the right.
-* Sorting applies to the entire history, not just the currently visible page, and the column layout is remembered separately for each list.
+* Sorting applies to the entire history, not just the currently visible page. Column layouts are remembered separately for each list.
 
 **Bug Fixes**
 
 * Fixed column headers in Timeline lists not aligning with the content below them.
-* Fixed copying images from the Photo Modal placing a local cache link on the clipboard instead of the actual image. Images can now be pasted directly into Discord, chats, or image editors.
+* Fixed copying images from the Photo Modal placing a local cache link on the clipboard instead of the actual image. Images can now be pasted directly into Discord, chats, and image editors.
 * Fixed the heatmap in user profiles using the button color instead of the VRC+ icon color.
+* Fixed an issue that prevented profile theme colors from being updated.
+* Fixed the "Most visited World" progress bars on vrc+ decorated profiles.

--- a/Services/TimelineService.cs
+++ b/Services/TimelineService.cs
@@ -1096,9 +1096,26 @@ public class TimelineService : IDisposable
         return result;
     }
 
-    public (List<TimelineEvent> Events, bool HasMore) GetEventsPaged(int limit, int offset, string typeFilter = "")
+    private static readonly HashSet<string> _eventSortCols =
+        new(StringComparer.OrdinalIgnoreCase) { "timestamp", "type", "user_name", "message", "world_name" };
+
+    private static string EventOrderBy(string? sortBy, string? sortDir)
     {
-        if (_optimizeMode && string.IsNullOrEmpty(typeFilter))
+        var col = !string.IsNullOrEmpty(sortBy) && _eventSortCols.Contains(sortBy) ? sortBy : "timestamp";
+        var dir = string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
+        return col == "timestamp"
+            ? $"ORDER BY timestamp {dir}"
+            : $"ORDER BY {col} {dir}, timestamp DESC";
+    }
+
+    public (List<TimelineEvent> Events, bool HasMore) GetEventsPaged(
+        int limit, int offset, string typeFilter = "", string? sortBy = null, string? sortDir = null)
+    {
+        var defaultSort = string.IsNullOrEmpty(sortBy)
+            || (string.Equals(sortBy, "timestamp", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase));
+
+        if (_optimizeMode && string.IsNullOrEmpty(typeFilter) && defaultSort)
         {
             lock (_lock)
             {
@@ -1112,7 +1129,7 @@ public class TimelineService : IDisposable
         {
             using var cmd = _db.CreateCommand();
             var typeClause = string.IsNullOrEmpty(typeFilter) ? "" : "WHERE type = $type";
-            cmd.CommandText = $"SELECT id FROM events {typeClause} ORDER BY timestamp DESC LIMIT $limit OFFSET $offset";
+            cmd.CommandText = $"SELECT id FROM events {typeClause} {EventOrderBy(sortBy, sortDir)} LIMIT $limit OFFSET $offset";
             cmd.Parameters.AddWithValue("$limit",  limit + 1);
             cmd.Parameters.AddWithValue("$offset", offset);
             if (!string.IsNullOrEmpty(typeFilter)) cmd.Parameters.AddWithValue("$type", typeFilter);
@@ -1198,6 +1215,11 @@ public class TimelineService : IDisposable
             }
         }
         catch { }
+
+        var rank = new Dictionary<string, int>(ids.Count);
+        for (int i = 0; i < ids.Count; i++) rank[ids[i]] = i;
+        result = result.OrderBy(e => rank.TryGetValue(e.Id, out var i) ? i : int.MaxValue).ToList();
+
         return (result, hasMore);
     }
 
@@ -1800,11 +1822,27 @@ public class TimelineService : IDisposable
         }
     }
 
+    private static readonly HashSet<string> _friendSortCols =
+        new(StringComparer.OrdinalIgnoreCase) { "timestamp", "type", "friend_name", "world_name" };
+
+    private static string FriendOrderBy(string? sortBy, string? sortDir)
+    {
+        var col = !string.IsNullOrEmpty(sortBy) && _friendSortCols.Contains(sortBy) ? sortBy : "timestamp";
+        var dir = string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase) ? "ASC" : "DESC";
+        return col == "timestamp"
+            ? $"ORDER BY timestamp {dir}"
+            : $"ORDER BY {col} {dir}, timestamp DESC";
+    }
+
     public (List<FriendTimelineEvent> Events, bool HasMore) GetFriendEventsPaged(
-        int limit, int offset, string? type = null)
+        int limit, int offset, string? type = null, string? sortBy = null, string? sortDir = null)
     {
         var hasType = !string.IsNullOrEmpty(type) && type != "all";
-        if (_optimizeMode && !hasType)
+        var defaultSort = string.IsNullOrEmpty(sortBy)
+            || (string.Equals(sortBy, "timestamp", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase));
+
+        if (_optimizeMode && !hasType && defaultSort)
         {
             lock (_lock)
             {
@@ -1816,16 +1854,17 @@ public class TimelineService : IDisposable
         var result = new List<FriendTimelineEvent>();
         try
         {
+            var orderBy = FriendOrderBy(sortBy, sortDir);
             using var cmd = _db.CreateCommand();
             cmd.CommandText = hasType
-                ? @"SELECT id,type,timestamp,friend_id,friend_name,friend_image,
+                ? $@"SELECT id,type,timestamp,friend_id,friend_name,friend_image,
                        world_id,world_name,world_thumb,location,old_value,new_value,left_at,tracked
                        FROM friend_events WHERE type=$type
-                       ORDER BY timestamp DESC LIMIT $limit OFFSET $offset"
-                : @"SELECT id,type,timestamp,friend_id,friend_name,friend_image,
+                       {orderBy} LIMIT $limit OFFSET $offset"
+                : $@"SELECT id,type,timestamp,friend_id,friend_name,friend_image,
                        world_id,world_name,world_thumb,location,old_value,new_value,left_at,tracked
                        FROM friend_events
-                       ORDER BY timestamp DESC LIMIT $limit OFFSET $offset";
+                       {orderBy} LIMIT $limit OFFSET $offset";
             cmd.Parameters.AddWithValue("$limit",  limit + 1);
             cmd.Parameters.AddWithValue("$offset", offset);
             if (hasType) cmd.Parameters.AddWithValue("$type", type);

--- a/Services/VRChatAPI/UsersAPI.cs
+++ b/Services/VRChatAPI/UsersAPI.cs
@@ -237,7 +237,18 @@ public class UsersAPI(VRChatApiService ctx)
             var resp = await ctx._http.PutAsync($"{VRChatApiService.BASE}/profile/theme/{Uri.EscapeDataString(themeId)}", content);
             var text = await resp.Content.ReadAsStringAsync();
             ctx.Log($"UpdateProfileTheme({themeId}): {(int)resp.StatusCode}");
-            if (resp.IsSuccessStatusCode) return JObject.Parse(text);
+            if (resp.IsSuccessStatusCode)
+            {
+                if ((text ?? "").TrimStart().StartsWith("{")) return JObject.Parse(text);
+                return new JObject
+                {
+                    ["id"]           = themeId,
+                    ["name"]         = name,
+                    ["buttonColor"]  = NormalizeThemeColor(button),
+                    ["iconColor"]    = NormalizeThemeColor(icon),
+                    ["subtextColor"] = NormalizeThemeColor(subtext),
+                };
+            }
         }
         catch (Exception ex) { ctx.Log($"UpdateProfileTheme exception: {ex.Message}"); }
         return null;

--- a/frontend/Styles/styles.css
+++ b/frontend/Styles/styles.css
@@ -399,7 +399,8 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
 .fd-modal-bar-actions { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
 .fd-modal-bar-actions .btn-notif { color: var(--tx1); }
 .fd-modal-bar-actions .fd-action-danger:hover { color: var(--err); }
-#myInstanceContent .fd-modal-bar { margin: 0; border-radius: 0; }
+#myInstanceContent .fd-modal-bar,
+#instanceInfoContent .fd-modal-bar { margin: 0; border-radius: 0; }
 
 .fd-banner img {
     width: 100%;

--- a/frontend/Styles/styles.css
+++ b/frontend/Styles/styles.css
@@ -978,13 +978,13 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     margin-bottom: 14px;
 }
 .iim-list {
-    --iim-grid-cols: 40px 70px minmax(78px, .72fr) 110px minmax(120px, 170px) 46px 62px minmax(82px, .8fr);
-    min-width: 808px;
+    --iim-grid-cols: 88px 82px minmax(120px, .72fr) 110px minmax(100px, 136px) 56px 98px minmax(100px, .8fr);
+    min-width: 812px;
     width: 100%;
 }
 .iim-list.has-timers {
-    --iim-grid-cols: 40px 72px 70px minmax(78px, .72fr) 110px minmax(120px, 170px) 46px 62px minmax(82px, .8fr);
-    min-width: 888px;
+    --iim-grid-cols: 88px 76px 82px minmax(120px, .72fr) 110px minmax(100px, 136px) 56px 98px minmax(100px, .8fr);
+    min-width: 892px;
 }
 .iim-list-head,
 .iim-user-row {
@@ -992,6 +992,33 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     grid-template-columns: var(--iim-grid-cols);
     align-items: center;
 }
+.iim-head-sortable {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    cursor: pointer;
+    user-select: none;
+    overflow: hidden;
+    transition: color .12s, background .12s;
+}
+.iim-head-sortable > span:not(.iim-head-arrow) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+.iim-head-sortable:hover { color: var(--tx1); background: var(--bg-hover); }
+.iim-head-sorted { color: var(--tx1); }
+
+.iim-head-arrow {
+    font-size: 12px !important;
+    opacity: 0;
+    flex-shrink: 0;
+    margin-left: auto;
+    transition: opacity .12s;
+}
+.iim-head-sortable:hover .iim-head-arrow { opacity: .55; }
+.iim-head-sorted .iim-head-arrow { opacity: 1; color: var(--accent); }
+
 .iim-list-head {
     position: sticky;
     top: 0;
@@ -1005,6 +1032,7 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     font-weight: 700;
     color: var(--tx3);
     letter-spacing: .05em;
+    text-transform: uppercase;
     text-align: left;
     white-space: nowrap;
     font-family: inherit;
@@ -1036,7 +1064,7 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     min-width: 0;
 }
 .iim-profile-cell {
-    padding: 5px 6px 5px 10px;
+    padding: 5px 8px;
 }
 .iim-cell-right {
     text-align: right;
@@ -1102,6 +1130,19 @@ html.deco-dashboard-on.nameplate-deco-on .dash-flocs-card > .dash-flocs-world-th
     font-weight: 700;
     color: var(--tx3);
 }
+.iim-status-cell {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+}
+.iim-status-cell > span:not(.vrc-status-dot) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
 .iim-name {
     color: var(--tx0);
     font-weight: 500;

--- a/frontend/core/logic/profile-theme.js
+++ b/frontend/core/logic/profile-theme.js
@@ -65,8 +65,6 @@ function _ptBlend(hex, target, amount) {
     return '#' + a.map((v, i) => Math.round(v + (b[i] - v) * amount).toString(16).padStart(2, '0')).join('');
 }
 
-// Keeps the theme hue but pushes it toward black or white until it reads on the
-// surface it is painted on. Bright themes on light surfaces are the bad case.
 function _ptReadable(color, bg, minRatio) {
     const c = ptHex(color);
     const b = ptHex(bg);

--- a/frontend/core/modals/group-modal/group-modal.js
+++ b/frontend/core/modals/group-modal/group-modal.js
@@ -1788,9 +1788,12 @@ function onGroupRoleMembers(data) {
         document.getElementById('grv-members-' + data.roleId),
     ].filter(Boolean);
     if (!targets.length) return;
-    const html = (!data.members || data.members.length === 0)
+
+    const members = (data.members || []).filter(m => Array.isArray(m.roleIds) && m.roleIds.includes(data.roleId));
+
+    const html = members.length === 0
         ? renderGroupEmptyMessage('groups.roles.no_members', 'No members with this role.')
-        : data.members.map(m => renderGroupMemberCard(m)).join('');
+        : members.map(m => renderGroupMemberCard(m)).join('');
     targets.forEach(el => { el.innerHTML = html; });
 }
 

--- a/frontend/core/modals/instance-modal/instance-modal.html
+++ b/frontend/core/modals/instance-modal/instance-modal.html
@@ -1,1 +1,1 @@
-        <div class="modal-box wide" id="instanceInfoContent" style="position:relative;max-width:1183px;width:95vw;"></div>
+        <div class="modal-box wide" id="instanceInfoContent" style="position:relative;max-width:1140px;width:95vw;padding:0;overflow:hidden;"></div>

--- a/frontend/core/modals/instance-modal/instance-modal.js
+++ b/frontend/core/modals/instance-modal/instance-modal.js
@@ -190,7 +190,16 @@ function openInstanceInfoModal() {
     const prevScroller  = c.querySelector('.mi-right-scroll');
     const prevScrollTop = prevScroller?.scrollTop || 0;
 
-    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}<div class="mi-layout">${leftHtml}${rightHtml}</div>`;
+    const leftHidden = _iimLeftHidden();
+    c.classList.toggle('iim-no-left', leftHidden);
+    const panelAction = {
+        icon: leftHidden ? 'left_panel_open' : 'left_panel_close',
+        title: leftHidden
+            ? t('instance.actions.show_world_panel', 'Show world panel')
+            : t('instance.actions.hide_world_panel', 'Hide world panel'),
+        onclick: 'iimToggleLeftPanel()',
+    };
+    c.innerHTML = `${renderModalBar(name, [panelAction, modalCloseAction('closeInstanceInfoModal()')])}<div class="mi-layout">${leftHtml}${rightHtml}</div>`;
 
     m.style.display = 'flex';
     if (prevScrollTop > 0) {
@@ -200,6 +209,17 @@ function openInstanceInfoModal() {
 }
 
 const IIM_SORT_KEY = 'vrcn_iim_sort';
+const IIM_LEFT_KEY = 'vrcn_iim_hide_left';
+
+function _iimLeftHidden() {
+    try { return localStorage.getItem(IIM_LEFT_KEY) === '1'; } catch { return false; }
+}
+
+function iimToggleLeftPanel() {
+    try { localStorage.setItem(IIM_LEFT_KEY, _iimLeftHidden() ? '0' : '1'); } catch {}
+    openInstanceInfoModal();
+}
+
 const IIM_STATUS_ORDER = ['join me', 'active', 'ask me', 'busy', 'offline'];
 let _iimSort = null;
 

--- a/frontend/core/modals/instance-modal/instance-modal.js
+++ b/frontend/core/modals/instance-modal/instance-modal.js
@@ -42,8 +42,7 @@ function openInstanceInfoModal() {
         return { ...u, _friend: friend || null };
     });
 
-    // Sort oldest join first (longest at top)
-    enriched.sort((a, b) => (a.joinedAt && b.joinedAt) ? a.joinedAt - b.joinedAt : 0);
+    _iimSortEntries(enriched);
 
     const now = Date.now();
     const hasTimers = enriched.some(u => u.joinedAt);
@@ -54,17 +53,17 @@ function openInstanceInfoModal() {
         return formatInstanceTimer(joinedAt, now);
     }
 
-    const timerHead = hasTimers ? `<div class="iim-head-cell iim-cell-right">${t('instance.table.timer', 'Timer')}</div>` : '';
+    const timerHead = hasTimers ? _iimHeadCell('timer', t('instance.table.timer', 'Timer')) : '';
     const listHead = `<div class="iim-list-head">
-        <div class="iim-head-cell">${t('instance.table.profile', 'Profile')}</div>
+        ${_iimHeadCell('profile', t('instance.table.profile', 'Profile'))}
         ${timerHead}
-        <div class="iim-head-cell iim-cell-right">${t('instance.table.joined', 'Joined')}</div>
-        <div class="iim-head-cell">${t('instance.table.display_name', 'Display Name')}</div>
-        <div class="iim-head-cell">${t('instance.table.rank', 'Rank')}</div>
-        <div class="iim-head-cell">${t('instance.table.status', 'Status')}</div>
-        <div class="iim-head-cell iim-cell-center">18+</div>
-        <div class="iim-head-cell iim-cell-center">${t('instance.table.platform', 'Platform')}</div>
-        <div class="iim-head-cell">${t('instance.table.language', 'Language')}</div>
+        ${_iimHeadCell('joined', t('instance.table.joined', 'Joined'))}
+        ${_iimHeadCell('name', t('instance.table.display_name', 'Display Name'))}
+        ${_iimHeadCell('rank', t('instance.table.rank', 'Rank'))}
+        ${_iimHeadCell('status', t('instance.table.status', 'Status'))}
+        ${_iimHeadCell('age', '18+')}
+        ${_iimHeadCell('platform', t('instance.table.platform', 'Platform'))}
+        ${_iimHeadCell('language', t('instance.table.language', 'Language'))}
     </div>`;
 
     const copyBadge = instNum
@@ -92,7 +91,7 @@ function openInstanceInfoModal() {
             ? `<div class="iim-av" style="background-image:url('${cssUrl(image)}')"></div>`
             : `<div class="iim-av iim-av-letter">${esc(displayName[0].toUpperCase())}</div>`;
         const timerCell = hasTimers
-            ? `<div class="iim-cell iim-cell-right iim-muted-cell">${esc(fmtTimer(u.joinedAt))}</div>`
+            ? `<div class="iim-cell iim-muted-cell">${esc(fmtTimer(u.joinedAt))}</div>`
             : '';
         const trust = getTrustRank(tags);
         const rankCell = `<div class="iim-cell">${trust ? `<span class="vrcn-badge ${trust.cls}" style="font-size:10px;">${esc(trust.label)}</span>` : ''}</div>`;
@@ -104,13 +103,13 @@ function openInstanceInfoModal() {
         let platIcon = '';
         if      (platform === 'standalonewindows') platIcon = `<span class="msi" title="${t('instance.platform.pc', 'PC')}" style="font-size:16px;color:var(--tx2);">computer</span>`;
         else if (platform === 'android')           platIcon = `<span class="msi" title="${t('instance.platform.quest', 'Quest')}" style="font-size:16px;color:var(--tx2);">view_in_ar</span>`;
-        const platformCell = `<div class="iim-cell iim-cell-center">${platIcon}</div>`;
+        const platformCell = `<div class="iim-cell">${platIcon}</div>`;
         const langsHtml = tags.filter(x => x.startsWith('language_'))
             .map(x => `<span class="vrcn-badge">${esc(LANG_MAP[x] || x.replace('language_', '').toUpperCase())}</span>`).join('');
         const langCell  = `<div class="iim-cell"><div class="iim-lang-cell">${langsHtml}</div></div>`;
         const nameCell  = `<div class="iim-cell"><span class="iim-name">${esc(displayName)}</span></div>`;
-        const ageCell   = `<div class="iim-cell iim-cell-center">${ageVerified ? `<span class="vrcn-badge" style="font-size:10px;color:#3ba55d;border-color:#3ba55d30;background:#3ba55d18;">18+</span>` : ''}</div>`;
-        const fromCell  = `<div class="iim-cell iim-cell-right iim-muted-cell">${u.joinedAt ? esc(fmtTime(new Date(u.joinedAt))) : '&mdash;'}</div>`;
+        const ageCell   = `<div class="iim-cell">${ageVerified ? `<span class="vrcn-badge" style="font-size:10px;color:#3ba55d;border-color:#3ba55d30;background:#3ba55d18;">18+</span>` : ''}</div>`;
+        const fromCell  = `<div class="iim-cell iim-muted-cell">${u.joinedAt ? esc(fmtTime(new Date(u.joinedAt))) : '&mdash;'}</div>`;
         let barHtml = '';
         if (iTotal > 0 && u.joinedAt) {
             const pStart   = u.joinedAt;
@@ -180,14 +179,13 @@ function openInstanceInfoModal() {
         ${data.ageGate ? `<span class="vrcn-badge" style="background:rgba(255,75,85,.15);color:var(--err);">${esc(t('worlds.instances.age_gated', 'Age Gated'))}</span>` : ''}
         ${getOwnerBadgeHtml(data.ownerId || '', data.ownerName || '', data.ownerGroup || '', 'closeInstanceInfoModal()')}
         <span class="vrcn-badge"><span class="msi" style="font-size:11px;">person</span>&nbsp;${users.length || data.nUsers || 0}${data.capacity ? '/' + data.capacity : ''}</span>
-        <div class="mi-header-actions"><button class="vrcn-button-round vrcn-btn-join" title="${esc(t('dashboard.instances.join_world', 'Join World'))}" onclick="closeInstanceInfoModal();sendToCS({action:'vrcJoinFriend',location:'${jsq(data.location || '')}'})"><span class="msi" style="font-size:14px;">login</span></button></div>
     </div>`;
 
     const playersHtml = enriched.length > 0
         ? `<div class="iim-list${hasTimers ? ' has-timers' : ''}">${listHead}<div class="iim-list-body">${bodyRows}</div></div>`
         : `<div style="padding:14px;color:var(--tx3);font-size:12px;">${t('instance.no_player_data_available', 'No player data available.')}</div>`;
 
-    const rightHtml = `<div class="mi-right"><div class="mi-right-scroll" style="overflow:auto;"><div class="mi-instance-list"><div class="mi-instance-card" style="overflow:visible;">${cardHeader}${playersHtml}</div></div></div></div>`;
+    const rightHtml = `<div class="mi-right"><div class="mi-right-scroll" style="overflow:auto;"><div class="mi-instance-list"><div class="mi-instance-card">${cardHeader}${playersHtml}</div></div></div></div>`;
 
     const prevScroller  = c.querySelector('.mi-right-scroll');
     const prevScrollTop = prevScroller?.scrollTop || 0;
@@ -199,6 +197,81 @@ function openInstanceInfoModal() {
         const newScroll = c.querySelector('.mi-right-scroll');
         if (newScroll) newScroll.scrollTop = prevScrollTop;
     }
+}
+
+const IIM_SORT_KEY = 'vrcn_iim_sort';
+const IIM_STATUS_ORDER = ['join me', 'active', 'ask me', 'busy', 'offline'];
+let _iimSort = null;
+
+function _iimSortState() {
+    if (_iimSort) return _iimSort;
+    let saved = null;
+    try { saved = JSON.parse(localStorage.getItem(IIM_SORT_KEY) || 'null'); } catch {}
+    _iimSort = {
+        id:  typeof saved?.id === 'string' ? saved.id : 'joined',
+        dir: saved?.dir === 'desc' ? 'desc' : 'asc',
+    };
+    return _iimSort;
+}
+
+function _iimTrustOrder(tags) {
+    const rank = (typeof getTrustRank === 'function') ? getTrustRank(tags || []) : null;
+    const order = ['rank-visitor', 'rank-new', 'rank-user', 'rank-known', 'rank-trusted'];
+    const idx = rank ? order.indexOf(rank.cls) : -1;
+    return idx < 0 ? -1 : idx;
+}
+
+function _iimSortValue(u, id) {
+    const live = u._friend;
+    switch (id) {
+        case 'timer':
+        case 'joined':   return u.joinedAt || 0;
+        case 'profile':
+        case 'name':     return (u.displayName || '').toLowerCase();
+        case 'rank':     return _iimTrustOrder((live?.tags?.length ? live.tags : null) || u.tags || []);
+        case 'status': {
+            const s = (live?.status || u.status || '').toLowerCase();
+            const idx = IIM_STATUS_ORDER.indexOf(s);
+            return idx < 0 ? IIM_STATUS_ORDER.length : idx;
+        }
+        case 'age':      return (live?.ageVerified || u.ageVerified) ? 1 : 0;
+        case 'platform': return (live?.platform || u.platform || '').toLowerCase();
+        case 'language': {
+            const tags = (live?.tags?.length ? live.tags : null) || u.tags || [];
+            const lang = tags.find(x => x.startsWith('language_')) || '';
+            return lang.replace('language_', '');
+        }
+        default:         return 0;
+    }
+}
+
+function _iimSortEntries(entries) {
+    const st  = _iimSortState();
+    const dir = st.dir === 'asc' ? 1 : -1;
+    entries.sort((a, b) => {
+        const va = _iimSortValue(a, st.id);
+        const vb = _iimSortValue(b, st.id);
+        if (va === vb) return (a.joinedAt || 0) - (b.joinedAt || 0);
+        return (va > vb ? 1 : -1) * dir;
+    });
+}
+
+function _iimHeadCell(id, label, extraCls) {
+    const st     = _iimSortState();
+    const active = st.id === id;
+    const arrow  = active ? (st.dir === 'asc' ? 'arrow_upward' : 'arrow_downward') : 'unfold_more';
+    return `<div class="iim-head-cell iim-head-sortable${active ? ' iim-head-sorted' : ''}${extraCls ? ' ' + extraCls : ''}"
+        onclick="iimSort('${id}')" title="${esc(t('timeline.list.header.sort_hint', 'Click to sort'))}">
+        <span>${esc(label)}</span><span class="msi iim-head-arrow">${arrow}</span>
+    </div>`;
+}
+
+function iimSort(id) {
+    const st = _iimSortState();
+    if (st.id === id) st.dir = st.dir === 'asc' ? 'desc' : 'asc';
+    else { st.id = id; st.dir = 'asc'; }
+    try { localStorage.setItem(IIM_SORT_KEY, JSON.stringify(st)); } catch {}
+    openInstanceInfoModal();
 }
 
 function closeInstanceInfoModal() {

--- a/frontend/core/modals/instance-modal/instance-modal.js
+++ b/frontend/core/modals/instance-modal/instance-modal.js
@@ -192,7 +192,7 @@ function openInstanceInfoModal() {
     const prevScroller  = c.querySelector('.mi-right-scroll');
     const prevScrollTop = prevScroller?.scrollTop || 0;
 
-    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}<div class="mi-layout" style="height:min(88vh,420px);max-height:420px;">${leftHtml}${rightHtml}</div>`;
+    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}<div class="mi-layout">${leftHtml}${rightHtml}</div>`;
 
     m.style.display = 'flex';
     if (prevScrollTop > 0) {

--- a/frontend/core/modals/instance-modal/instance-modal.js
+++ b/frontend/core/modals/instance-modal/instance-modal.js
@@ -105,10 +105,8 @@ function openInstanceInfoModal() {
         if      (platform === 'standalonewindows') platIcon = `<span class="msi" title="${t('instance.platform.pc', 'PC')}" style="font-size:16px;color:var(--tx2);">computer</span>`;
         else if (platform === 'android')           platIcon = `<span class="msi" title="${t('instance.platform.quest', 'Quest')}" style="font-size:16px;color:var(--tx2);">view_in_ar</span>`;
         const platformCell = `<div class="iim-cell iim-cell-center">${platIcon}</div>`;
-        const langTags  = tags.filter(t => t.startsWith('language_'));
-        const langsHtml = langTags.map(t =>
-            `<span class="vrcn-badge">${esc(LANG_MAP[t] || t.replace('language_', '').toUpperCase())}</span>`
-        ).join('');
+        const langsHtml = tags.filter(x => x.startsWith('language_'))
+            .map(x => `<span class="vrcn-badge">${esc(LANG_MAP[x] || x.replace('language_', '').toUpperCase())}</span>`).join('');
         const langCell  = `<div class="iim-cell"><div class="iim-lang-cell">${langsHtml}</div></div>`;
         const nameCell  = `<div class="iim-cell"><span class="iim-name">${esc(displayName)}</span></div>`;
         const ageCell   = `<div class="iim-cell iim-cell-center">${ageVerified ? `<span class="vrcn-badge" style="font-size:10px;color:#3ba55d;border-color:#3ba55d30;background:#3ba55d18;">18+</span>` : ''}</div>`;
@@ -119,10 +117,10 @@ function openInstanceInfoModal() {
             const pEnd     = u.leftAt || now;
             const leftPct  = Math.max(0, Math.min(100, (pStart - iStart) / iTotal * 100));
             const widthPct = Math.max(0, Math.min(100 - leftPct, (pEnd - pStart) / iTotal * 100));
-            const barCls   = (u._friend || (currentVrcUser && u.id === currentVrcUser.id)) ? ' friend' : '';
+            const barCls   = (u._friend || isSelf) ? ' friend' : '';
             barHtml = `<div class="iim-user-bar"><div class="tl-player-bar-wrap"><div class="tl-player-bar${barCls}" style="left:${leftPct.toFixed(1)}%;width:${widthPct.toFixed(1)}%"></div></div></div>`;
         }
-        const itemClick = id ? ` onclick="openFriendDetail('${jsq(id)}')"` : '';
+        const itemClick    = id ? ` onclick="openFriendDetail('${jsq(id)}')"` : '';
         const clickableCls = id ? ' clickable' : '';
         return `<div class="iim-user-item${clickableCls}"${itemClick}>
             <div class="iim-user-row">
@@ -146,37 +144,60 @@ function openInstanceInfoModal() {
     if (othersEnriched.length > 0)
         bodyRows += `<div class="iim-section-label"><div class="fd-group-rep-label" style="margin:0;">${tf('instance.sections.players_in_instance', { count: othersEnriched.length }, 'PLAYERS IN INSTANCE ({count})')}</div></div>` + othersEnriched.map(makeRow).join('');
 
-    const tableHtml = enriched.length > 0
-        ? `<div class="iim-scroll"><div class="iim-list${hasTimers ? ' has-timers' : ''}">${listHead}<div class="iim-list-body">${bodyRows}</div></div></div>`
-        : `<div style="padding:14px 0;color:var(--tx3);font-size:12px;">${t('instance.no_player_data_available', 'No player data available.')}</div>`;
+    const wc = (typeof dashWorldCache !== 'undefined' && data.worldId) ? (dashWorldCache[data.worldId] || null) : null;
+    if (data.worldId && (!wc || (!wc.description && !wc._descFetched)) && typeof sendToCS === 'function') sendToCS({ action: 'vrcGetWorldInstancesDetail', worldId: data.worldId, locations: data.location ? [data.location] : [] });
+    const worldAuthor   = wc?.authorName || '';
+    const worldAuthorId = wc?.authorId || '';
+    const worldDesc     = wc?.description || '';
 
-    const prevIimScroller = c.querySelector('.iim-scroll');
-    const prevIimScrollTop = prevIimScroller?.scrollTop || 0;
-    const prevIimScrollLeft = prevIimScroller?.scrollLeft || 0;
-    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}${bannerHtml}
-    <div class="fd-content${thumb ? ' fd-has-banner' : ''}" style="padding:16px;">
-        <h2 style="margin:0 0 4px;color:var(--tx0);font-size:18px;">${esc(name)}</h2>
-        <div class="fd-badges-row">
-            <span class="vrcn-badge ${instCls}">${instLabel}</span>
-            ${data.ageGate ? `<span class="vrcn-badge" style="background:rgba(255,75,85,.15);color:var(--err);">${esc(t('worlds.instances.age_gated', 'Age Gated'))}</span>` : ''}
-            ${getOwnerBadgeHtml(data.ownerId || '', data.ownerName || '', data.ownerGroup || '', 'closeInstanceInfoModal()')}
-            ${copyBadge}
-            <span style="font-size:11px;color:var(--tx3);margin-left:4px;"><span class="msi" style="font-size:12px;vertical-align:-2px;">person</span> ${users.length || data.nUsers || 0}${data.capacity ? '/' + data.capacity : ''}</span>
+    const bannerImg = thumb
+        ? `<img class="mi-world-banner" src="${thumb}" onerror="this.style.display='none'">`
+        : '';
+
+    const authorHtml = worldAuthor
+        ? `<div class="mi-world-author">${t('worlds.meta.by', 'by')} ${worldAuthorId
+            ? `<span onclick="closeInstanceInfoModal();navOpenModal('friend','${jsq(worldAuthorId)}','${jsq(worldAuthor)}')" style="display:inline-flex;align-items:center;padding:1px 8px;border-radius:20px;background:var(--bg-hover);font-size:11px;font-weight:600;color:var(--tx1);cursor:pointer;line-height:1.8;">${esc(worldAuthor)}</span>`
+            : esc(worldAuthor)}</div>`
+        : '';
+    const descHtml = worldDesc ? `<div class="mi-world-description">${esc(worldDesc)}</div>` : '';
+
+    const leftHtml = `<div class="mi-left">
+        <div class="mi-world-banner-wrap">${bannerImg}<div class="mi-world-banner-fade"></div></div>
+        <div class="mi-world-info">
+            <div class="mi-world-name">${esc(name)}</div>
+            ${authorHtml}
+            ${descHtml}
         </div>
-        ${tableHtml}
-        <div class="fd-actions">
-            <button class="vrcn-button-round" onclick="closeInstanceInfoModal();openInviteModal()"><span class="msi">person_add</span> ${t('instance.actions.invite', 'Invite')}</button>
-            <button class="vrcn-button-round" onclick="closeInstanceInfoModal();openWorldSearchDetail('${wid}')">${t('dashboard.instances.open_world', 'Open World')}</button>
+        <div class="mi-left-actions">
+            <button class="vrcn-button-round mi-action-btn" onclick="closeInstanceInfoModal();openInviteModal()"><span class="msi" style="font-size:14px;">person_add</span> ${t('instance.actions.invite', 'Invite')}</button>
+            <button class="vrcn-button-round mi-action-btn" onclick="closeInstanceInfoModal();openWorldSearchDetail('${wid}')">${t('dashboard.instances.open_world', 'Open World')}</button>
         </div>
     </div>`;
 
+    const cardHeader = `<div class="mi-instance-header">
+        <span class="vrcn-badge ${instCls}">${instLabel}</span>
+        ${copyBadge}
+        ${data.ageGate ? `<span class="vrcn-badge" style="background:rgba(255,75,85,.15);color:var(--err);">${esc(t('worlds.instances.age_gated', 'Age Gated'))}</span>` : ''}
+        ${getOwnerBadgeHtml(data.ownerId || '', data.ownerName || '', data.ownerGroup || '', 'closeInstanceInfoModal()')}
+        <span class="vrcn-badge"><span class="msi" style="font-size:11px;">person</span>&nbsp;${users.length || data.nUsers || 0}${data.capacity ? '/' + data.capacity : ''}</span>
+        <div class="mi-header-actions"><button class="vrcn-button-round vrcn-btn-join" title="${esc(t('dashboard.instances.join_world', 'Join World'))}" onclick="closeInstanceInfoModal();sendToCS({action:'vrcJoinFriend',location:'${jsq(data.location || '')}'})"><span class="msi" style="font-size:14px;">login</span></button></div>
+    </div>`;
+
+    const playersHtml = enriched.length > 0
+        ? `<div class="iim-list${hasTimers ? ' has-timers' : ''}">${listHead}<div class="iim-list-body">${bodyRows}</div></div>`
+        : `<div style="padding:14px;color:var(--tx3);font-size:12px;">${t('instance.no_player_data_available', 'No player data available.')}</div>`;
+
+    const rightHtml = `<div class="mi-right"><div class="mi-right-scroll" style="overflow:auto;"><div class="mi-instance-list"><div class="mi-instance-card" style="overflow:visible;">${cardHeader}${playersHtml}</div></div></div></div>`;
+
+    const prevScroller  = c.querySelector('.mi-right-scroll');
+    const prevScrollTop = prevScroller?.scrollTop || 0;
+
+    c.innerHTML = `${renderModalBar(name, [modalCloseAction('closeInstanceInfoModal()')])}<div class="mi-layout" style="height:min(88vh,420px);max-height:420px;">${leftHtml}${rightHtml}</div>`;
+
     m.style.display = 'flex';
-    if (prevIimScrollTop > 0 || prevIimScrollLeft > 0) {
-        const newIimScroll = c.querySelector('.iim-scroll');
-        if (newIimScroll) {
-            newIimScroll.scrollTop = prevIimScrollTop;
-            newIimScroll.scrollLeft = prevIimScrollLeft;
-        }
+    if (prevScrollTop > 0) {
+        const newScroll = c.querySelector('.mi-right-scroll');
+        if (newScroll) newScroll.scrollTop = prevScrollTop;
     }
 }
 

--- a/frontend/core/modals/my-instance-modal/my-instance-modal.css
+++ b/frontend/core/modals/my-instance-modal/my-instance-modal.css
@@ -22,6 +22,11 @@
     min-height: 0;
 }
 
+#instanceInfoContent .mi-instance-list,
+#instanceInfoContent .mi-instance-card {
+    min-width: max-content;
+}
+
 /* === Left Panel === */
 
 .mi-left {

--- a/frontend/core/modals/my-instance-modal/my-instance-modal.css
+++ b/frontend/core/modals/my-instance-modal/my-instance-modal.css
@@ -27,6 +27,10 @@
     min-width: max-content;
 }
 
+#instanceInfoContent.iim-no-left > .mi-layout { grid-template-columns: minmax(0, 1fr); }
+#instanceInfoContent.iim-no-left .mi-left { display: none; }
+#instanceInfoContent.iim-no-left .mi-right { border-radius: 0 0 14px 14px; }
+
 /* === Left Panel === */
 
 .mi-left {

--- a/frontend/core/modals/my-instance-modal/my-instance-modal.css
+++ b/frontend/core/modals/my-instance-modal/my-instance-modal.css
@@ -9,6 +9,19 @@
     max-height: 380px;
 }
 
+#instanceInfoContent {
+    display: flex;
+    flex-direction: column;
+    height: var(--fd-compact-h);
+}
+
+#instanceInfoContent > .mi-layout {
+    flex: 1 1 0;
+    height: auto;
+    max-height: none;
+    min-height: 0;
+}
+
 /* === Left Panel === */
 
 .mi-left {

--- a/frontend/core/modals/my-instance-modal/my-instance-modal.js
+++ b/frontend/core/modals/my-instance-modal/my-instance-modal.js
@@ -58,6 +58,24 @@ function handleWorldInstancesDetail(payload) {
         });
     }
 
+    if (payload.world && payload.worldId && typeof dashWorldCache !== 'undefined') {
+        const w = payload.world;
+        dashWorldCache[payload.worldId] = Object.assign({}, dashWorldCache[payload.worldId], {
+            name:              w.name || dashWorldCache[payload.worldId]?.name || '',
+            authorName:        w.authorName || '',
+            authorId:          w.authorId || '',
+            description:       w.description || '',
+            thumbnailImageUrl: w.thumb || dashWorldCache[payload.worldId]?.thumbnailImageUrl || '',
+            _descFetched:      true,
+        });
+        const iim = document.getElementById('modalInstanceInfo');
+        if (iim && iim.style.display !== 'none'
+            && typeof currentInstanceData !== 'undefined' && currentInstanceData?.worldId === payload.worldId
+            && typeof openInstanceInfoModal === 'function') {
+            openInstanceInfoModal();
+        }
+    }
+
     const m = document.getElementById('modalMyInstance');
     if (!m || m.style.display === 'none' || _miModalWorldId !== payload.worldId) return;
 

--- a/frontend/core/modals/my-profile-modal/my-profile-modal.js
+++ b/frontend/core/modals/my-profile-modal/my-profile-modal.js
@@ -1260,11 +1260,15 @@ function _mypApplyActiveThemeColors() {
 let _ptEditId = '';
 let _ptEditColors = { button: '#064b5c', icon: '#6ae3f9', subtext: '#a9a9a9' };
 
-function openProfileThemeEditor(themeId) {
+function openProfileThemeEditor(themeId, preset) {
     const u = currentVrcUser || {};
     const th = (Array.isArray(u.themes) ? u.themes : []).find(x => x.id === themeId);
     _ptEditId = themeId || '';
-    _ptEditColors = {
+    _ptEditColors = preset ? {
+        button:  ptHex(preset.button,  '#064b5c'),
+        icon:    ptHex(preset.icon,    '#6ae3f9'),
+        subtext: ptHex(preset.subtext, '#a9a9a9'),
+    } : {
         button:  ptHex(th && th.buttonColor,  '#064b5c'),
         icon:    ptHex(th && th.iconColor,    '#6ae3f9'),
         subtext: ptHex(th && th.subtextColor, '#a9a9a9'),
@@ -1293,7 +1297,7 @@ function openProfileThemeEditor(themeId) {
             <div class="pt-preview" id="ptPreview"></div>
             <div class="pt-row">
                 <span class="pt-label">${esc(t('profiles.theme.name', 'Name'))}</span>
-                <input type="text" id="ptName" class="vrcn-edit-field" style="flex:1;" maxlength="32" value="${esc((th && th.name) || '')}">
+                <input type="text" id="ptName" class="vrcn-edit-field" style="flex:1;" maxlength="32" value="${esc(preset ? (preset.name || '') : ((th && th.name) || ''))}">
             </div>
             ${rows}
         </div>

--- a/frontend/core/modals/timeline-modal/timeline-modal.js
+++ b/frontend/core/modals/timeline-modal/timeline-modal.js
@@ -832,7 +832,7 @@ function _tlPersonalProfHtml(ev) {
     return _tlListProfHtml(ev.userImage, ev.userName);
 }
 
-function buildPersonalListHtml(events) {
+function buildPersonalListHtml(events, staticHeader) {
     if (!events.length) {
         return `<div class="empty-msg">${esc(t('timeline.list.empty.personal', 'No timeline events match your filter.'))}</div>`;
     }
@@ -846,24 +846,16 @@ function buildPersonalListHtml(events) {
         const listMeetCount = ev.type === 'meet_again' ? (ev.meetCount || 0) : 0;
         const listTypeLabel = listMeetCount > 0 ? `${meta.label} (${listMeetCount})` : meta.label;
 
-        rows += `<tr class="tl-list-row" data-tlid="${esc(ev.id)}" onclick="openTlDetail('${ei}')">
-            <td class="tl-list-dt">${esc(`${tlFormatShortDate(ev.timestamp)} | ${tlFormatTime(ev.timestamp)}`)}</td>
-            <td class="tl-list-type"><span class="msi tl-list-icon" style="color:${color}">${meta.icon}</span><span>${esc(listTypeLabel)}</span></td>
-            <td style="width:34px;padding:4px 8px;">${_tlPersonalProfHtml(ev)}</td>
-            <td class="tl-list-user">${userHtml || tlListNaHtml()}</td>
-            <td class="tl-list-detail">${detail || tlListNaHtml()}</td>
-        </tr>`;
+        rows += tlTableRow('personal', ` data-tlid="${esc(ev.id)}" onclick="openTlDetail('${ei}')"`, {
+            dt:      `<td class="tl-list-dt">${esc(`${tlFormatShortDate(ev.timestamp)} | ${tlFormatTime(ev.timestamp)}`)}</td>`,
+            type:    `<td class="tl-list-type"><span class="msi tl-list-icon" style="color:${color}">${meta.icon}</span><span>${esc(listTypeLabel)}</span></td>`,
+            profile: `<td class="tl-list-profile">${_tlPersonalProfHtml(ev)}</td>`,
+            user:    `<td class="tl-list-user">${userHtml || tlListNaHtml()}</td>`,
+            detail:  `<td class="tl-list-detail">${detail || tlListNaHtml()}</td>`,
+        });
     });
 
-    return `<div class="tl-list-wrap">
-        <table class="tl-list-table">
-            <colgroup><col style="width:155px"><col style="width:135px"><col style="width:80px"><col style="width:130px"><col></colgroup>
-            <thead><tr>
-                <th>${esc(t('timeline.list.header.date_time', 'Date / Time'))}</th><th>${esc(t('timeline.list.header.type', 'Type'))}</th><th>${esc(t('timeline.list.header.profile', 'Profile'))}</th><th>${esc(t('timeline.list.header.user', 'User'))}</th><th>${esc(t('timeline.list.header.detail', 'Detail'))}</th>
-            </tr></thead>
-            <tbody>${rows}</tbody>
-        </table>
-    </div>`;
+    return tlTableHtml('personal', rows, staticHeader);
 }
 
 function _tlListPlayerAvatars(players, max) {
@@ -938,7 +930,7 @@ function _tlListData(ev) {
 // List View — Friends Timeline
 // ═══════════════════════════════════════════════════════════════════
 
-function buildFriendListHtml(events) {
+function buildFriendListHtml(events, staticHeader) {
     if (!events.length) {
         return `<div class="empty-msg">${esc(t('timeline.list.empty.friends', 'No friend activity logged yet.'))}</div>`;
     }
@@ -953,24 +945,16 @@ function buildFriendListHtml(events) {
             ? `openFtGpsDetail('${ei}')`
             : `openFtDetail('${ei}')`;
 
-        rows += `<tr class="tl-list-row" data-ftid="${esc(ev.id)}" onclick="${clickAction}">
-            <td class="tl-list-dt">${esc(`${tlFormatShortDate(ev.timestamp)} | ${tlFormatTime(ev.timestamp)}`)}</td>
-            <td class="tl-list-type"><span class="msi tl-list-icon" style="color:${color}">${meta.icon}</span><span>${esc(meta.label)}</span></td>
-            <td style="width:34px;padding:4px 8px;">${_tlListProfHtml(ev.friendImage, ev.friendName)}</td>
-            <td class="tl-list-user">${esc(ev.friendName || t('timeline.unknown', 'Unknown'))}</td>
-            <td class="tl-list-detail">${detail || tlListNaHtml()}</td>
-        </tr>`;
+        rows += tlTableRow('friends', ` data-ftid="${esc(ev.id)}" onclick="${clickAction}"`, {
+            dt:      `<td class="tl-list-dt">${esc(`${tlFormatShortDate(ev.timestamp)} | ${tlFormatTime(ev.timestamp)}`)}</td>`,
+            type:    `<td class="tl-list-type"><span class="msi tl-list-icon" style="color:${color}">${meta.icon}</span><span>${esc(meta.label)}</span></td>`,
+            profile: `<td class="tl-list-profile">${_tlListProfHtml(ev.friendImage, ev.friendName)}</td>`,
+            user:    `<td class="tl-list-user">${esc(ev.friendName || t('timeline.unknown', 'Unknown'))}</td>`,
+            detail:  `<td class="tl-list-detail">${detail || tlListNaHtml()}</td>`,
+        });
     });
 
-    return `<div class="tl-list-wrap">
-        <table class="tl-list-table">
-            <colgroup><col style="width:155px"><col style="width:135px"><col style="width:80px"><col style="width:130px"><col></colgroup>
-            <thead><tr>
-                <th>${esc(t('timeline.list.header.date_time', 'Date / Time'))}</th><th>${esc(t('timeline.list.header.type', 'Type'))}</th><th>${esc(t('timeline.list.header.profile', 'Profile'))}</th><th>${esc(t('timeline.list.header.user', 'User'))}</th><th>${esc(t('timeline.list.header.detail', 'Detail'))}</th>
-            </tr></thead>
-            <tbody>${rows}</tbody>
-        </table>
-    </div>`;
+    return tlTableHtml('friends', rows, staticHeader);
 }
 
 function _ftListDetail(ev) {

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -335,6 +335,14 @@
     padding: 18px;
 }
 
+#modalFriendDetail.fd-style-compact .fd-right-scroll > .fd-tabs,
+#modalMyProfile.fd-style-compact .fd-right-scroll > .fd-tabs{
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    box-shadow: 0 -9px 0 18px var(--bg-card);
+}
+
 #modalFriendDetail.fd-style-compact #fdTabJson > .json-viewer,
 #modalMyProfile.fd-style-compact #mypTabJson > .json-viewer{
     max-height: none !important;

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -445,6 +445,7 @@
     background: var(--bg-hover);
 }
 .has-profile-theme { --hm-online: var(--pt-icon, var(--accent)); }
+.has-profile-theme .ts-bar { background: var(--pt-icon, var(--accent)); }
 .fd-hm-axis {
     display: flex;
     gap: 6px;

--- a/frontend/core/modals/user-modal/user-modal.css
+++ b/frontend/core/modals/user-modal/user-modal.css
@@ -444,6 +444,7 @@
     border-radius: 2px;
     background: var(--bg-hover);
 }
+.has-profile-theme { --hm-online: var(--pt-icon, var(--accent)); }
 .fd-hm-axis {
     display: flex;
     gap: 6px;

--- a/frontend/core/modals/user-modal/user-modal.js
+++ b/frontend/core/modals/user-modal/user-modal.js
@@ -1637,7 +1637,7 @@ function drawOnlineHeatmap(payload, ids) {
             const intensity = max > 0 ? Math.sqrt(val / max) : 0;
             const title = `${dayLabels[d]} ${String(h).padStart(2, '0')}:00 · ${fdFmtMinutes(val)}`;
             const style = val > 0
-                ? `style="background:color-mix(in srgb, var(--accent) ${Math.round(20 + intensity * 80)}%, transparent);"`
+                ? `style="background:color-mix(in srgb, var(--hm-online, var(--accent)) ${Math.round(20 + intensity * 80)}%, transparent);"`
                 : '';
             cells += `<div class="fd-hm-cell" ${style} title="${esc(title)}"></div>`;
         }

--- a/frontend/core/modals/user-modal/user-modal.js
+++ b/frontend/core/modals/user-modal/user-modal.js
@@ -1942,6 +1942,31 @@ function renderFdModerationCard(userId) {
     if (card) card.innerHTML = _buildModCardInner(userId);
 }
 
+function _fdCopyableThemeColors(d) {
+    if (!d || typeof ptHex !== 'function') return null;
+    let button  = ptHex(d.themeButtonColor);
+    let icon    = ptHex(d.themeIconColor);
+    let subtext = ptHex(d.themeSubtextColor);
+    if (!button && !icon && !subtext) {
+        const th = Array.isArray(d.themes) && d.themeId ? d.themes.find(x => x && x.id === d.themeId) : null;
+        if (th) {
+            button  = ptHex(th.buttonColor);
+            icon    = ptHex(th.iconColor);
+            subtext = ptHex(th.subtextColor);
+        }
+    }
+    if (!button && !icon && !subtext) return null;
+    return { button, icon, subtext };
+}
+
+function copyProfileThemeFromDetail() {
+    const d = currentFriendDetail;
+    const c = _fdCopyableThemeColors(d);
+    if (!c) { showToast(false, t('profiles.theme.no_theme', 'This profile has no theme to copy.')); return; }
+    if (typeof openProfileThemeEditor !== 'function') return;
+    openProfileThemeEditor('', { button: c.button, icon: c.icon, subtext: c.subtext, name: d.displayName || '' });
+}
+
 function _fdBuildTaskbarActions(d) {
     const _fid  = jsq(d.id || '');
     const _mBlk = Array.isArray(blockedData)      && blockedData.some(x => x.targetUserId === d.id);
@@ -1960,6 +1985,7 @@ function _fdBuildTaskbarActions(d) {
             { icon: _mAvt ? 'visibility' : 'visibility_off', label: _mAvt ? t('context_menu.friend.show_avatar', 'Show Avatar')           : t('context_menu.friend.hide_avatar', 'Hide Avatar'),           onclick: `sendToCS({action:'${_mAvt ? 'vrcShowAvatar' : 'vrcHideAvatar'}',userId:'${_fid}'})` },
             { icon: _mInt ? 'touch_app' : 'do_not_touch',    label: _mInt ? t('context_menu.friend.interact_on', 'Turn On Interactions') : t('context_menu.friend.interact_off', 'Turn Off Interactions'), onclick: `sendToCS({action:'${_mInt ? 'vrcInteractOn' : 'vrcInteractOff'}',userId:'${_fid}'})` },
         ] },
+        _fdCopyableThemeColors(d) ? { icon: 'palette', label: t('context_menu.copy_theme', 'Copy Theme'), onclick: `copyProfileThemeFromDetail()` } : null,
     ].filter(Boolean);
     const out = [
         { icon: 'refresh', iconClass: _fdRefreshing ? 'fd-action-spin' : '', title: t('common.refresh', 'Refresh'), label: t('common.refresh', 'Refresh'), onclick: `refreshFriendDetailModal('${_fid}')` },

--- a/frontend/core/modals/world-modal/world-modal.css
+++ b/frontend/core/modals/world-modal/world-modal.css
@@ -115,6 +115,14 @@
     padding: 18px;
 }
 
+#modalDetail.wd-style-compact .fd-right-scroll > .fd-tabs,
+#modalDetail.gd-style-compact .fd-right-scroll > .fd-tabs {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    box-shadow: 0 -9px 0 18px var(--bg-card);
+}
+
 #modalDetail.wd-style-compact #wdTabJson > .json-viewer,
 #modalDetail.gd-style-compact #gdTabJson > .json-viewer {
     max-height: none !important;
@@ -255,6 +263,13 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: 18px;
+}
+
+#modalAvatarDetail.av-style-compact .fd-right-scroll > .fd-tabs {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    box-shadow: 0 -9px 0 18px var(--bg-card);
 }
 #modalAvatarDetail.av-style-compact #avTabJson > .json-viewer {
     max-height: none !important;

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -373,6 +373,8 @@
   "timeline.list.header.profile": "Profil",
   "timeline.list.header.user": "Benutzer",
   "timeline.list.header.detail": "Detail",
+  "timeline.list.header.hint": "Klicken zum Sortieren, ziehen zum Verschieben",
+  "timeline.list.header.reorder": "Zum Verschieben ziehen",
   "timeline.list.from": "von {name}",
   "timeline.list.na": "k. A.",
   "timeline.value.cleared": "(geleert)",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -374,6 +374,7 @@
   "timeline.list.header.user": "Benutzer",
   "timeline.list.header.detail": "Detail",
   "timeline.list.header.hint": "Klicken zum Sortieren, ziehen zum Verschieben",
+  "timeline.list.header.sort_hint": "Klicken zum Sortieren",
   "timeline.list.header.reorder": "Zum Verschieben ziehen",
   "timeline.list.from": "von {name}",
   "timeline.list.na": "k. A.",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1575,6 +1575,7 @@
   "context_menu.friend.invite_group": "In Gruppe einladen",
   "context_menu.friend.invite_group_sent": "Einladung gesendet!",
   "context_menu.friend.boop": "Boop!",
+  "context_menu.copy_theme": "Theme kopieren",
   "context_menu.friend.messenger": "Messenger",
   "context_menu.friend.unfavorite": "Aus Favoriten entfernen",
   "context_menu.friend.move_group": "In Gruppe verschieben",

--- a/frontend/i18n/de.json
+++ b/frontend/i18n/de.json
@@ -1627,6 +1627,8 @@
   "instance.no_player_data": "Keine Spielerdaten",
   "instance.no_player_data_available": "Keine Spielerdaten verfuegbar.",
   "instance.actions.invite": "Einladen",
+  "instance.actions.hide_world_panel": "Weltbereich ausblenden",
+  "instance.actions.show_world_panel": "Weltbereich einblenden",
   "instance.actions.force_join": "Beitreten",
   "instance.sections.friends_in_instance": "FREUNDE IN DIESER INSTANZ ({count})",
   "instance.sections.players_in_instance": "SPIELER IN DIESER INSTANZ ({count})",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -372,6 +372,7 @@
   "timeline.list.header.user": "User",
   "timeline.list.header.detail": "Detail",
   "timeline.list.header.hint": "Click to sort, drag to reorder",
+  "timeline.list.header.sort_hint": "Click to sort",
   "timeline.list.header.reorder": "Drag to reorder",
   "timeline.list.from": "from {name}",
   "timeline.list.na": "N/A",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1666,6 +1666,8 @@
   "instance.no_player_data": "No player data",
   "instance.no_player_data_available": "No player data available.",
   "instance.actions.invite": "Invite",
+  "instance.actions.hide_world_panel": "Hide world panel",
+  "instance.actions.show_world_panel": "Show world panel",
   "instance.actions.force_join": "Force-Join",
   "instance.sections.friends_in_instance": "FRIENDS IN INSTANCE ({count})",
   "instance.sections.players_in_instance": "PLAYERS IN INSTANCE ({count})",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -1621,6 +1621,7 @@
   "context_menu.friend.invite_group": "Invite to Group",
   "context_menu.friend.invite_group_sent": "Invite sent!",
   "context_menu.friend.boop": "Boop!",
+  "context_menu.copy_theme": "Copy Theme",
   "context_menu.friend.messenger": "Messenger",
   "context_menu.friend.unfavorite": "Unfavorite",
   "context_menu.friend.move_group": "Move to Group",

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -371,6 +371,8 @@
   "timeline.list.header.profile": "Profile",
   "timeline.list.header.user": "User",
   "timeline.list.header.detail": "Detail",
+  "timeline.list.header.hint": "Click to sort, drag to reorder",
+  "timeline.list.header.reorder": "Drag to reorder",
   "timeline.list.from": "from {name}",
   "timeline.list.na": "N/A",
   "timeline.value.cleared": "(cleared)",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1623,6 +1623,8 @@
   "instance.no_player_data": "Sin datos de jugadores",
   "instance.no_player_data_available": "No hay datos de jugadores disponibles.",
   "instance.actions.invite": "Invitar",
+  "instance.actions.hide_world_panel": "Ocultar panel del mundo",
+  "instance.actions.show_world_panel": "Mostrar panel del mundo",
   "instance.actions.force_join": "Unirse",
   "instance.sections.friends_in_instance": "AMIGOS EN LA INSTANCIA ({count})",
   "instance.sections.players_in_instance": "JUGADORES EN LA INSTANCIA ({count})",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -374,6 +374,7 @@
   "timeline.list.header.user": "Usuario",
   "timeline.list.header.detail": "Detalle",
   "timeline.list.header.hint": "Haz clic para ordenar, arrastra para reordenar",
+  "timeline.list.header.sort_hint": "Haz clic para ordenar",
   "timeline.list.header.reorder": "Arrastra para reordenar",
   "timeline.list.from": "de {name}",
   "timeline.list.na": "N/D",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -373,6 +373,8 @@
   "timeline.list.header.profile": "Perfil",
   "timeline.list.header.user": "Usuario",
   "timeline.list.header.detail": "Detalle",
+  "timeline.list.header.hint": "Haz clic para ordenar, arrastra para reordenar",
+  "timeline.list.header.reorder": "Arrastra para reordenar",
   "timeline.list.from": "de {name}",
   "timeline.list.na": "N/D",
   "timeline.value.cleared": "(borrado)",

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -1571,6 +1571,7 @@
   "context_menu.friend.invite_group": "Invitar al grupo",
   "context_menu.friend.invite_group_sent": "¡Invitación enviada!",
   "context_menu.friend.boop": "¡Boop!",
+  "context_menu.copy_theme": "Copiar tema",
   "context_menu.friend.messenger": "Mensajero",
   "context_menu.friend.unfavorite": "Quitar de favoritos",
   "context_menu.friend.move_group": "Mover al grupo",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -373,6 +373,8 @@
   "timeline.list.header.profile": "Profil",
   "timeline.list.header.user": "Utilisateur",
   "timeline.list.header.detail": "Détail",
+  "timeline.list.header.hint": "Cliquer pour trier, glisser pour réorganiser",
+  "timeline.list.header.reorder": "Glisser pour réorganiser",
   "timeline.list.from": "de {name}",
   "timeline.list.na": "N/A",
   "timeline.value.cleared": "(effacé)",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -374,6 +374,7 @@
   "timeline.list.header.user": "Utilisateur",
   "timeline.list.header.detail": "Détail",
   "timeline.list.header.hint": "Cliquer pour trier, glisser pour réorganiser",
+  "timeline.list.header.sort_hint": "Cliquer pour trier",
   "timeline.list.header.reorder": "Glisser pour réorganiser",
   "timeline.list.from": "de {name}",
   "timeline.list.na": "N/A",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1571,6 +1571,7 @@
   "context_menu.friend.invite_group": "Inviter dans le groupe",
   "context_menu.friend.invite_group_sent": "Invitation envoyée !",
   "context_menu.friend.boop": "Boop !",
+  "context_menu.copy_theme": "Copier le thème",
   "context_menu.friend.messenger": "Messager",
   "context_menu.friend.unfavorite": "Retirer des favoris",
   "context_menu.friend.move_group": "Déplacer dans le groupe",

--- a/frontend/i18n/fr.json
+++ b/frontend/i18n/fr.json
@@ -1623,6 +1623,8 @@
   "instance.no_player_data": "Pas de données de joueurs",
   "instance.no_player_data_available": "Aucune donnée de joueur disponible.",
   "instance.actions.invite": "Inviter",
+  "instance.actions.hide_world_panel": "Masquer le panneau du monde",
+  "instance.actions.show_world_panel": "Afficher le panneau du monde",
   "instance.actions.force_join": "Rejoindre",
   "instance.sections.friends_in_instance": "AMIS DANS L'INSTANCE ({count})",
   "instance.sections.players_in_instance": "JOUEURS DANS L'INSTANCE ({count})",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -1570,6 +1570,7 @@
   "context_menu.friend.invite_group": "グループに招待",
   "context_menu.friend.invite_group_sent": "招待を送信しました！",
   "context_menu.friend.boop": "Boop!",
+  "context_menu.copy_theme": "テーマをコピー",
   "context_menu.friend.messenger": "メッセンジャー",
   "context_menu.friend.unfavorite": "お気に入り解除",
   "context_menu.friend.move_group": "グループに移動",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -373,6 +373,8 @@
   "timeline.list.header.profile": "プロフィール",
   "timeline.list.header.user": "ユーザー",
   "timeline.list.header.detail": "詳細",
+  "timeline.list.header.hint": "クリックで並べ替え、ドラッグで列を移動",
+  "timeline.list.header.reorder": "ドラッグして並べ替え",
   "timeline.list.from": "{name}から",
   "timeline.list.na": "N/A",
   "timeline.value.cleared": "(クリア済み)",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -1622,6 +1622,8 @@
   "instance.no_player_data": "プレイヤーデータなし",
   "instance.no_player_data_available": "プレイヤーデータがありません。",
   "instance.actions.invite": "招待",
+  "instance.actions.hide_world_panel": "ワールドパネルを隠す",
+  "instance.actions.show_world_panel": "ワールドパネルを表示",
   "instance.actions.force_join": "強制参加",
   "instance.sections.friends_in_instance": "インスタンス内のフレンド ({count})",
   "instance.sections.players_in_instance": "インスタンス内のプレイヤー ({count})",

--- a/frontend/i18n/ja.json
+++ b/frontend/i18n/ja.json
@@ -374,6 +374,7 @@
   "timeline.list.header.user": "ユーザー",
   "timeline.list.header.detail": "詳細",
   "timeline.list.header.hint": "クリックで並べ替え、ドラッグで列を移動",
+  "timeline.list.header.sort_hint": "クリックで並べ替え",
   "timeline.list.header.reorder": "ドラッグして並べ替え",
   "timeline.list.from": "{name}から",
   "timeline.list.na": "N/A",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -1564,6 +1564,7 @@
   "context_menu.friend.invite_group": "Пригласить в группу",
   "context_menu.friend.invite_group_sent": "Приглашение отправлено",
   "context_menu.friend.boop": "Boop",
+  "context_menu.copy_theme": "Копировать тему",
   "context_menu.friend.messenger": "Мессенджер",
   "context_menu.friend.unfavorite": "Убрать из избранного",
   "context_menu.friend.move_group": "Переместить в группу",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -1609,6 +1609,8 @@
   "instance.no_player_data": "Нет данных об игроке",
   "instance.no_player_data_available": "Данные недоступны",
   "instance.actions.invite": "Пригласить",
+  "instance.actions.hide_world_panel": "Скрыть панель мира",
+  "instance.actions.show_world_panel": "Показать панель мира",
   "instance.actions.force_join": "Принудительно войти",
   "instance.sections.friends_in_instance": "Друзья в инстансе",
   "instance.sections.players_in_instance": "Игроки в инстансе",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -376,6 +376,8 @@
   "timeline.list.header.profile": "Профиль",
   "timeline.list.header.user": "Пользователь",
   "timeline.list.header.detail": "Детали",
+  "timeline.list.header.hint": "Нажмите для сортировки, перетащите для перемещения",
+  "timeline.list.header.reorder": "Перетащите для перемещения",
   "timeline.list.from": "От",
   "timeline.list.na": "Н/Д",
   "timeline.value.cleared": "Очищено",

--- a/frontend/i18n/ru.json
+++ b/frontend/i18n/ru.json
@@ -377,6 +377,7 @@
   "timeline.list.header.user": "Пользователь",
   "timeline.list.header.detail": "Детали",
   "timeline.list.header.hint": "Нажмите для сортировки, перетащите для перемещения",
+  "timeline.list.header.sort_hint": "Нажмите для сортировки",
   "timeline.list.header.reorder": "Перетащите для перемещения",
   "timeline.list.from": "От",
   "timeline.list.na": "Н/Д",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -1623,6 +1623,8 @@
   "instance.no_player_data": "无玩家数据",
   "instance.no_player_data_available": "无可用的玩家数据。",
   "instance.actions.invite": "邀请",
+  "instance.actions.hide_world_panel": "隐藏世界面板",
+  "instance.actions.show_world_panel": "显示世界面板",
   "instance.actions.force_join": "强制加入",
   "instance.sections.friends_in_instance": "实例中的好友 ({count})",
   "instance.sections.players_in_instance": "实例中的玩家 ({count})",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -1571,6 +1571,7 @@
   "context_menu.friend.invite_group": "邀请加入群组",
   "context_menu.friend.invite_group_sent": "邀请已发送！",
   "context_menu.friend.boop": "Boop！",
+  "context_menu.copy_theme": "复制主题",
   "context_menu.friend.messenger": "信使",
   "context_menu.friend.unfavorite": "取消收藏",
   "context_menu.friend.move_group": "移動到分組",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -374,6 +374,7 @@
   "timeline.list.header.user": "用户",
   "timeline.list.header.detail": "详情",
   "timeline.list.header.hint": "点击排序，拖动可调整顺序",
+  "timeline.list.header.sort_hint": "点击排序",
   "timeline.list.header.reorder": "拖动可调整顺序",
   "timeline.list.from": "来自 {name}",
   "timeline.list.na": "无",

--- a/frontend/i18n/zh-CN.json
+++ b/frontend/i18n/zh-CN.json
@@ -373,6 +373,8 @@
   "timeline.list.header.profile": "头像",
   "timeline.list.header.user": "用户",
   "timeline.list.header.detail": "详情",
+  "timeline.list.header.hint": "点击排序，拖动可调整顺序",
+  "timeline.list.header.reorder": "拖动可调整顺序",
   "timeline.list.from": "来自 {name}",
   "timeline.list.na": "无",
   "timeline.value.cleared": "（已清除）",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -123,7 +123,7 @@
     </div>
     <div class="app-body">
     <div class="sidebar" id="sidebarEl">
-        <div class="logo"><div class="logo-icon" id="logoIcon">V</div><div class="logo-txt"><div class="logo-text-row"><div class="logo-text">VRCNext</div></div><div class="logo-sub">v2026.35.3</div></div></div>
+        <div class="logo"><div class="logo-icon" id="logoIcon">V</div><div class="logo-txt"><div class="logo-text-row"><div class="logo-text">VRCNext</div></div><div class="logo-sub">v2026.35.4</div></div></div>
         <div class="nav vrcn-scrollbar" id="navEl"></div>
         <div class="clock-area"><div class="clock-time" id="clock">00:00:00</div><div class="clock-date" id="clockDate"></div></div>
         <div class="play-area"><button class="btn-play" onclick="playVRChat()"><span class="msi play-icon">play_arrow</span><span class="pl" data-i18n="sidebar.play_vrchat">Play VRChat</span></button></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -739,6 +739,7 @@
             'modules/tools/space-flight/space-flight.js',
             'modules/tools/frame-shot/frame-shot.js',
             'modules/tools/osc-tool/osc-tool.js',
+            'modules/timeline/list-table.js',
             'modules/timeline/timeline.js',
             'modules/timeline/game-log.js',
             'modules/timeline/instance-chart.js',

--- a/frontend/modules/dashboard/dashboard.js
+++ b/frontend/modules/dashboard/dashboard.js
@@ -1192,11 +1192,11 @@ function _dashTlRows(events, isFriend) {
     const sliced = events.slice(0, 8);
     if (isFriend) {
         return typeof buildFriendListHtml === 'function'
-            ? buildFriendListHtml(sliced)
+            ? buildFriendListHtml(sliced, true)
             : `<div class="empty-msg">${t('dashboard.timeline.empty', 'No events yet')}</div>`;
     }
     return typeof buildPersonalListHtml === 'function'
-        ? buildPersonalListHtml(sliced)
+        ? buildPersonalListHtml(sliced, true)
         : `<div class="empty-msg">${t('dashboard.timeline.empty', 'No events yet')}</div>`;
 }
 

--- a/frontend/modules/media-library/library.js
+++ b/frontend/modules/media-library/library.js
@@ -1143,7 +1143,7 @@ function _photoBuildToolbar(x) {
 
     const copyBtns = x.remote
         ? `<button class="pdt-btn" onclick="photoDownload()" title="${esc(t('context_menu.image.download', 'Download Image'))}"><span class="msi">download</span></button>
-           <button class="pdt-btn" onclick="photoCopyLink()" title="${esc(t('common.share', 'Share'))}"><span class="msi">link</span></button>`
+           <button class="pdt-btn" onclick="photoCopyImage()" title="${esc(t('library.actions.copy_clipboard', 'Copy to clipboard'))}"><span class="msi">content_copy</span></button>`
         : `<button class="pdt-btn" onclick="photoCopy()" title="${esc(t('library.actions.copy_clipboard', 'Copy to clipboard'))}"><span class="msi">content_copy</span></button>`;
 
     return `<div class="photo-detail-toolbar" onmousedown="event.stopPropagation()">
@@ -1282,12 +1282,36 @@ function photoDownload() {
     sendToCS({ action: 'invDownload', url: it.url, fileName });
 }
 
-function photoCopyLink() {
+function _photoBlobToPng(blob) {
+    return new Promise((resolve, reject) => {
+        const objUrl = URL.createObjectURL(blob);
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width  = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+            canvas.getContext('2d').drawImage(img, 0, 0);
+            URL.revokeObjectURL(objUrl);
+            canvas.toBlob(b => b ? resolve(b) : reject(new Error('encode failed')), 'image/png');
+        };
+        img.onerror = () => { URL.revokeObjectURL(objUrl); reject(new Error('load failed')); };
+        img.src = objUrl;
+    });
+}
+
+async function photoCopyImage() {
     const it = _photoState.item;
     if (!it || !it.url) return;
-    navigator.clipboard.writeText(it.url)
-        .then(() => showToast(true, t('common.link_copied', 'Link copied!')))
-        .catch(() => {});
+    try {
+        const resp = await fetch(it.url);
+        if (!resp.ok) throw new Error('fetch failed');
+        let blob = await resp.blob();
+        if (blob.type !== 'image/png') blob = await _photoBlobToPng(blob);
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+        showToast(true, t('export.copied', 'Copied to clipboard'));
+    } catch {
+        showToast(false, t('export.copy_failed', 'Copy failed'));
+    }
 }
 
 function photoNavPrev() { _photoNav(-1); }

--- a/frontend/modules/timeline/game-log.js
+++ b/frontend/modules/timeline/game-log.js
@@ -76,29 +76,26 @@ function renderGameLog() {
 function buildGlListHtml(entries) {
     if (!entries.length) return `<div class="empty-msg">${esc(t('gamelog.empty', 'No game log entries yet.'))}</div>`;
 
-    let rows = '';
-    entries.forEach(ev => {
-        const meta  = GL_META[ev.type] ?? { icon: 'circle', color: 'var(--tx3)', label: ev.type };
-        const dateStr = tlFormatShortDate(ev.timestamp);
-        const timeStr = tlFormatTime(ev.timestamp);
-        rows += `<tr class="tl-list-row">
-            <td class="tl-list-dt">${esc(`${dateStr} | ${timeStr}`)}</td>
-            <td class="tl-list-type"><span class="msi tl-list-icon" style="color:${meta.color}">${meta.icon}</span><span>${esc(meta.label)}</span></td>
-            <td class="tl-list-detail" colspan="2">${esc(ev.message || '')}${ev.detail ? `<span class="tl-list-na" style="margin-left:6px;font-size:10px;">${esc(ev.detail.length > 80 ? ev.detail.slice(0, 80) + '…' : ev.detail)}</span>` : ''}</td>
-        </tr>`;
+    const glMeta = ev => GL_META[ev.type] ?? { icon: 'circle', color: 'var(--tx3)', label: ev.type };
+    const sorted = tlTableSortLocal('gamelog', entries, {
+        dt:    e => e.timestamp || '',
+        type:  e => (glMeta(e).label || '').toLowerCase(),
+        event: e => (e.message || '').toLowerCase(),
     });
 
-    return `<div class="tl-list-wrap">
-        <table class="tl-list-table">
-            <colgroup><col style="width:155px"><col style="width:120px"><col></colgroup>
-            <thead><tr>
-                <th>${esc(t('timeline.list.header.date_time', 'Date / Time'))}</th>
-                <th>${esc(t('timeline.list.header.type', 'Type'))}</th>
-                <th>${esc(t('gamelog.header.event', 'Event'))}</th>
-            </tr></thead>
-            <tbody>${rows}</tbody>
-        </table>
-    </div>`;
+    let rows = '';
+    sorted.forEach(ev => {
+        const meta  = glMeta(ev);
+        const dateStr = tlFormatShortDate(ev.timestamp);
+        const timeStr = tlFormatTime(ev.timestamp);
+        rows += tlTableRow('gamelog', '', {
+            dt:    `<td class="tl-list-dt">${esc(`${dateStr} | ${timeStr}`)}</td>`,
+            type:  `<td class="tl-list-type"><span class="msi tl-list-icon" style="color:${meta.color}">${meta.icon}</span><span>${esc(meta.label)}</span></td>`,
+            event: `<td class="tl-list-detail">${esc(ev.message || '')}${ev.detail ? `<span class="tl-list-na" style="margin-left:6px;font-size:10px;">${esc(ev.detail.length > 80 ? ev.detail.slice(0, 80) + '…' : ev.detail)}</span>` : ''}</td>`,
+        });
+    });
+
+    return tlTableHtml('gamelog', rows);
 }
 
 // ── Card / Timeline view ──────────────────────────────────────────────

--- a/frontend/modules/timeline/list-table.js
+++ b/frontend/modules/timeline/list-table.js
@@ -1,0 +1,304 @@
+/* === Timeline List Tables — column order + sorting === */
+
+const TL_TABLE_DEFS = {
+    personal: [
+        { id: 'dt',      key: 'timeline.list.header.date_time', fallback: 'Date / Time', width: '155px', sort: 'timestamp' },
+        { id: 'type',    key: 'timeline.list.header.type',      fallback: 'Type',        width: '135px', sort: 'type' },
+        { id: 'profile', key: 'timeline.list.header.profile',   fallback: 'Profile',     width: '80px',  sort: 'user_name' },
+        { id: 'user',    key: 'timeline.list.header.user',      fallback: 'User',        width: '130px', sort: 'user_name' },
+        { id: 'detail',  key: 'timeline.list.header.detail',    fallback: 'Detail',      width: '',      sort: 'message' },
+    ],
+    friends: [
+        { id: 'dt',      key: 'timeline.list.header.date_time', fallback: 'Date / Time', width: '155px', sort: 'timestamp' },
+        { id: 'type',    key: 'timeline.list.header.type',      fallback: 'Type',        width: '135px', sort: 'type' },
+        { id: 'profile', key: 'timeline.list.header.profile',   fallback: 'Profile',     width: '80px',  sort: 'friend_name' },
+        { id: 'user',    key: 'timeline.list.header.user',      fallback: 'User',        width: '130px', sort: 'friend_name' },
+        { id: 'detail',  key: 'timeline.list.header.detail',    fallback: 'Detail',      width: '',      sort: 'world_name' },
+    ],
+    gamelog: [
+        { id: 'dt',    key: 'timeline.list.header.date_time', fallback: 'Date / Time', width: '155px', sort: 'timestamp' },
+        { id: 'type',  key: 'timeline.list.header.type',      fallback: 'Type',        width: '120px', sort: 'label' },
+        { id: 'event', key: 'gamelog.header.event',           fallback: 'Event',       width: '',      sort: 'message' },
+    ],
+};
+
+const _tlTableState = {};
+
+function _tlTableStorageKey(list) { return 'vrcn_tl_table_' + list; }
+
+function tlTableState(list) {
+    if (_tlTableState[list]) return _tlTableState[list];
+    let saved = null;
+    try { saved = JSON.parse(localStorage.getItem(_tlTableStorageKey(list)) || 'null'); } catch {}
+    const defs  = TL_TABLE_DEFS[list] || [];
+    const valid = defs.map(c => c.id);
+    const order = Array.isArray(saved?.order)
+        ? saved.order.filter(id => valid.includes(id)).concat(valid.filter(id => !saved.order.includes(id)))
+        : valid.slice();
+    _tlTableState[list] = {
+        order,
+        sortId:  typeof saved?.sortId === 'string' ? saved.sortId : 'dt',
+        sortDir: saved?.sortDir === 'asc' ? 'asc' : 'desc',
+    };
+    return _tlTableState[list];
+}
+
+function _tlTableSave(list) {
+    try { localStorage.setItem(_tlTableStorageKey(list), JSON.stringify(tlTableState(list))); } catch {}
+}
+
+function tlTableSortField(list) {
+    const st  = tlTableState(list);
+    const def = (TL_TABLE_DEFS[list] || []).find(c => c.id === st.sortId);
+    return { field: def?.sort || 'timestamp', dir: st.sortDir };
+}
+
+function tlSortParams(list) {
+    const { field, dir } = tlTableSortField(list);
+    return { sortBy: field, sortDir: dir };
+}
+
+function tlTableColumns(list) {
+    const defs = TL_TABLE_DEFS[list] || [];
+    return tlTableState(list).order.map(id => defs.find(c => c.id === id)).filter(Boolean);
+}
+
+function tlTableSort(list, colId) {
+    const st = tlTableState(list);
+    if (st.sortId === colId) st.sortDir = st.sortDir === 'asc' ? 'desc' : 'asc';
+    else { st.sortId = colId; st.sortDir = 'desc'; }
+    _tlTableSave(list);
+    _tlTableRerender(list);
+}
+
+function _tlTableRerender(list) {
+    if (list === 'personal' && typeof reloadTimelineSorted === 'function') reloadTimelineSorted();
+    else if (list === 'friends' && typeof reloadFriendTimelineSorted === 'function') reloadFriendTimelineSorted();
+    else if (list === 'gamelog' && typeof renderGameLog === 'function') renderGameLog();
+}
+
+function _tlTableRedraw(list) {
+    if (list === 'personal' && typeof filterTimeline === 'function') filterTimeline();
+    else if (list === 'friends' && typeof filterFriendTimeline === 'function') filterFriendTimeline();
+    else if (list === 'gamelog' && typeof renderGameLog === 'function') renderGameLog();
+}
+
+const _TL_DRAG_MS   = 200;
+const _TL_DRAG_EASE = 'cubic-bezier(.2,.7,.3,1)';
+let _tlDrag = null;
+
+function _tlColIndex(th) {
+    return Array.prototype.indexOf.call(th.parentElement.children, th);
+}
+
+function _tlPlaceColumn(table, from, to, mode) {
+    if (from === to) return;
+    const containers = [
+        table.querySelector('colgroup'),
+        table.querySelector('thead tr'),
+        ...table.querySelectorAll('tbody tr'),
+    ];
+    containers.forEach(row => {
+        if (!row || row.children.length <= Math.max(from, to)) return;
+        const cell = row.children[from];
+        const ref  = row.children[to];
+        if (!cell || !ref) return;
+        row.insertBefore(cell, mode === 'before' ? ref : ref.nextSibling);
+    });
+}
+
+function _tlHeadSnap(headRow) {
+    const map = new Map();
+    Array.from(headRow.children).forEach(el => map.set(el, el.getBoundingClientRect().left));
+    return map;
+}
+
+function _tlHeadFlip(headRow, prev) {
+    Array.from(headRow.children).forEach(el => {
+        if (!prev.has(el)) return;
+        const dx = prev.get(el) - el.getBoundingClientRect().left;
+        if (!dx) return;
+        el.animate(
+            [{ transform: `translateX(${dx}px)` }, { transform: 'translateX(0)' }],
+            { duration: _TL_DRAG_MS, easing: _TL_DRAG_EASE }
+        );
+    });
+}
+
+function _tlDragDown(e) {
+    const grip = e.target.closest('.tl-th-grip');
+    if (!grip || e.button !== 0) return;
+    const th    = grip.closest('th.tl-th');
+    const table = th?.closest('.tl-list-table');
+    const list  = table?.dataset.tlList;
+    if (!th || !table || !list) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const rect  = th.getBoundingClientRect();
+    const ghost = th.cloneNode(true);
+    Object.assign(ghost.style, {
+        position: 'fixed',
+        top: rect.top + 'px',
+        left: rect.left + 'px',
+        width: rect.width + 'px',
+        height: rect.height + 'px',
+        display: 'flex',
+        alignItems: 'center',
+        pointerEvents: 'none',
+        zIndex: '10020',
+        opacity: '0.92',
+        boxShadow: '0 14px 40px rgba(0,0,0,.55)',
+        borderRadius: '8px',
+        background: 'var(--bg-card)',
+        transform: 'scale(1.02)',
+    });
+    document.body.appendChild(ghost);
+    th.classList.add('tl-th-dragging');
+
+    _tlDrag = { list, table, th, ghost, offsetX: e.clientX - rect.left, offsetY: e.clientY - rect.top, lastKey: null };
+    grip.setPointerCapture?.(e.pointerId);
+    window.addEventListener('pointermove', _tlDragMove);
+    window.addEventListener('pointerup', _tlDragUp);
+    window.addEventListener('pointercancel', _tlDragUp);
+    document.body.style.cursor = 'grabbing';
+}
+
+function _tlDragMove(e) {
+    if (!_tlDrag) return;
+    const { table, th, ghost } = _tlDrag;
+    ghost.style.top  = (e.clientY - _tlDrag.offsetY) + 'px';
+    ghost.style.left = (e.clientX - _tlDrag.offsetX) + 'px';
+
+    const headRow = table.querySelector('thead tr');
+    const others  = Array.from(headRow.children).filter(cell => cell !== th);
+
+    let drop = null;
+    for (const cell of others) {
+        const rect = cell.getBoundingClientRect();
+        if (e.clientX < rect.left + rect.width / 2) { drop = { mode: 'before', target: cell }; break; }
+        drop = { mode: 'after', target: cell };
+    }
+    if (!drop) return;
+
+    const key = drop.mode + ':' + drop.target.className;
+    if (key === _tlDrag.lastKey) return;
+    _tlDrag.lastKey = key;
+
+    const prev = _tlHeadSnap(headRow);
+    _tlPlaceColumn(table, _tlColIndex(th), _tlColIndex(drop.target), drop.mode);
+    _tlHeadFlip(headRow, prev);
+}
+
+function _tlDragUp() {
+    if (!_tlDrag) return;
+    window.removeEventListener('pointermove', _tlDragMove);
+    window.removeEventListener('pointerup', _tlDragUp);
+    window.removeEventListener('pointercancel', _tlDragUp);
+    document.body.style.cursor = '';
+
+    const { list, table, th, ghost } = _tlDrag;
+    _tlDrag = null;
+
+    const finalRect = th.getBoundingClientRect();
+    const ghostRect = ghost.getBoundingClientRect();
+    ghost.animate(
+        [
+            { transform: 'translate(0,0) scale(1.02)', opacity: 0.92 },
+            { transform: `translate(${finalRect.left - ghostRect.left}px,${finalRect.top - ghostRect.top}px) scale(1)`, opacity: 1 },
+        ],
+        { duration: _TL_DRAG_MS, easing: _TL_DRAG_EASE, fill: 'forwards' }
+    ).onfinish = () => {
+        ghost.remove();
+        th.classList.remove('tl-th-dragging');
+
+        const order = Array.from(table.querySelectorAll('thead th.tl-th'))
+            .map(cell => (cell.className.match(/tl-th-([a-z]+)\b/) || [])[1])
+            .filter(id => id && id !== 'sorted' && id !== 'dragging');
+        const st = tlTableState(list);
+        if (order.length === st.order.length) {
+            st.order = order;
+            _tlTableSave(list);
+        }
+        _tlTableRedraw(list);
+    };
+}
+
+document.addEventListener('pointerdown', _tlDragDown, true);
+
+function tlTableHtml(list, rowsHtml, staticHeader) {
+    const cols = tlTableColumns(list);
+    const st   = tlTableState(list);
+
+    const colgroup = cols.map(c => `<col${c.width ? ` style="width:${c.width}"` : ''}>`).join('');
+
+    if (staticHeader) {
+        const plain = cols.map(c => `<th class="tl-th-${c.id}">${esc(t(c.key, c.fallback))}</th>`).join('');
+        return `<div class="tl-list-wrap">
+            <table class="tl-list-table">
+                <colgroup>${colgroup}</colgroup>
+                <thead><tr>${plain}</tr></thead>
+                <tbody>${rowsHtml}</tbody>
+            </table>
+        </div>`;
+    }
+
+    const heads = cols.map(c => {
+        const active = st.sortId === c.id;
+        const arrow  = active ? (st.sortDir === 'asc' ? 'arrow_upward' : 'arrow_downward') : 'unfold_more';
+        return `<th class="tl-th tl-th-${c.id}${active ? ' tl-th-sorted' : ''}"
+            onclick="tlTableSort('${list}','${c.id}')"
+            title="${esc(t('timeline.list.header.hint', 'Click to sort, drag to reorder'))}">
+            <span class="tl-th-label">${esc(t(c.key, c.fallback))}</span>
+            <span class="msi tl-th-arrow">${arrow}</span>
+            <span class="msi tl-th-grip" title="${esc(t('timeline.list.header.reorder', 'Drag to reorder'))}">drag_indicator</span>
+        </th>`;
+    }).join('');
+
+    return `<div class="tl-list-wrap">
+        <table class="tl-list-table" data-tl-list="${list}">
+            <colgroup>${colgroup}</colgroup>
+            <thead><tr>${heads}</tr></thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>
+    </div>`;
+}
+
+function tlTableRow(list, attrs, cells) {
+    const tds = tlTableColumns(list).map(c => cells[c.id] || '<td></td>').join('');
+    return `<tr class="tl-list-row"${attrs}>${tds}</tr>`;
+}
+
+const TL_LOCAL_ACCESSORS = {
+    personal: {
+        dt:      e => e.timestamp || '',
+        type:    e => (e.type || '').toLowerCase(),
+        profile: e => (e.userName || '').toLowerCase(),
+        user:    e => (e.userName || '').toLowerCase(),
+        detail:  e => (e.message || '').toLowerCase(),
+    },
+    friends: {
+        dt:      e => e.timestamp || '',
+        type:    e => (e.type || '').toLowerCase(),
+        profile: e => (e.friendName || '').toLowerCase(),
+        user:    e => (e.friendName || '').toLowerCase(),
+        detail:  e => (e.worldName || '').toLowerCase(),
+    },
+};
+
+function tlSortEventsLocal(list, events) {
+    return tlTableSortLocal(list, events, TL_LOCAL_ACCESSORS[list] || {});
+}
+
+function tlTableSortLocal(list, entries, accessors) {
+    const st = tlTableState(list);
+    const get = accessors[st.sortId];
+    if (!get) return entries;
+    const dir = st.sortDir === 'asc' ? 1 : -1;
+    return entries.slice().sort((a, b) => {
+        const va = get(a), vb = get(b);
+        if (va === vb) return 0;
+        return (va > vb ? 1 : -1) * dir;
+    });
+}

--- a/frontend/modules/timeline/timeline.css
+++ b/frontend/modules/timeline/timeline.css
@@ -35,6 +35,38 @@
     white-space: nowrap;
 }
 
+.tl-list-table thead th.tl-th {
+    cursor: pointer;
+    user-select: none;
+    transition: color .12s, background .12s;
+}
+.tl-list-table thead th.tl-th > * { vertical-align: middle; }
+.tl-list-table thead th.tl-th:hover { color: var(--tx1); background: var(--bg-hover); }
+.tl-list-table thead th.tl-th-sorted { color: var(--tx1); }
+
+.tl-th-grip {
+    font-size: 13px !important;
+    color: var(--tx3);
+    opacity: 0;
+    cursor: grab;
+    margin-left: 4px;
+    transition: opacity .12s;
+    touch-action: none;
+}
+.tl-list-table thead th.tl-th:hover .tl-th-grip { opacity: .7; }
+.tl-th-grip:active { cursor: grabbing; }
+
+.tl-th-arrow {
+    font-size: 13px !important;
+    margin-left: 2px;
+    opacity: 0;
+    transition: opacity .12s;
+}
+.tl-list-table thead th.tl-th:hover .tl-th-arrow { opacity: .55; }
+.tl-list-table thead th.tl-th-sorted .tl-th-arrow { opacity: 1; color: var(--accent); }
+
+.tl-list-table thead th.tl-th-dragging { opacity: .35; }
+
 .tl-list-row {
     border-bottom: 1px solid var(--brd);
     cursor: pointer;
@@ -82,11 +114,16 @@
     width: 130px;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.tl-list-row td.tl-list-user,
+.tl-list-table thead th.tl-th-user {
     padding-left: 28px;
 }
 
-.tl-list-table thead th:nth-child(4) {
-    padding-left: 28px;
+.tl-list-row td.tl-list-profile,
+.tl-list-table thead th.tl-th-profile {
+    padding-left: 14px;
 }
 
 .tl-list-detail {

--- a/frontend/modules/timeline/timeline.js
+++ b/frontend/modules/timeline/timeline.js
@@ -449,7 +449,7 @@ function refreshTimeline() {
     }
     const typeParam = tlFilter === 'all' ? '' : tlFilter;
     if (tlDateFilter) sendToCS({ action: 'getTimelineByDate', date: tlDateFilter, type: typeParam });
-    else              sendToCS({ action: 'getTimeline', type: typeParam });
+    else              sendToCS({ action: 'getTimeline', type: typeParam, ...tlSortParams('personal') });
 }
 
 function renderTimeline(payload) {
@@ -532,7 +532,7 @@ function setTlFilter(f) {
     if (c) c.innerHTML = sk(tlViewMode === 'list' ? 'timeline-list' : 'timeline');
     const typeParam = f === 'all' ? '' : f;
     if (tlDateFilter) sendToCS({ action: 'getTimelineByDate', date: tlDateFilter, type: typeParam });
-    else              sendToCS({ action: 'getTimeline', type: typeParam });
+    else              sendToCS({ action: 'getTimeline', type: typeParam, ...tlSortParams('personal') });
 }
 
 function filterTimeline() {
@@ -583,7 +583,7 @@ function filterTimeline() {
     // Date filter: all events loaded at once → paginate client-side
     // Normal mode: server-side pagination (timelineEvents = current page only)
     const eventsToRender = tlDateFilter
-        ? timelineEvents.slice(tlListPage * 100, (tlListPage + 1) * 100)
+        ? tlSortEventsLocal('personal', timelineEvents).slice(tlListPage * 100, (tlListPage + 1) * 100)
         : timelineEvents;
     const totalCount = tlDateFilter ? timelineEvents.length : tlTotal;
     const totalPages = totalCount > 0
@@ -683,12 +683,26 @@ function loadMoreTimeline() {
     tlLoading = true;
     const btn = document.getElementById('tlLoadMoreBtn');
     if (btn) { btn.disabled = true; btn.innerHTML = `<span class="msi" style="font-size:16px;">hourglass_empty</span> ${esc(t('timeline.load_more.loading', 'Loading...'))}`; }
-    sendToCS({ action: 'getTimelinePage', offset: tlOffset, type: tlFilter === 'all' ? '' : tlFilter });
+    sendToCS({ action: 'getTimelinePage', offset: tlOffset, type: tlFilter === 'all' ? '' : tlFilter, ...tlSortParams('personal') });
 }
 
 function buildTlPagination(page, totalPages, hasMore) {
     const countHtml = tlTotal > 0 ? `<span style="font-size:11px;color:var(--tx3);padding:0 8px;">${esc(tlTotalSummary(tlTotal))}</span>` : '';
     return buildPaginator(page, totalPages, 'tlGoPage', countHtml, hasMore) || countHtml;
+}
+
+function reloadTimelineSorted() {
+    if (tlDateFilter) { filterTimeline(); return; }
+    tlListPage = 0;
+    tlOffset   = 0;
+    sendToCS({ action: 'getTimelinePage', offset: 0, type: tlFilter === 'all' ? '' : tlFilter, ...tlSortParams('personal') });
+}
+
+function reloadFriendTimelineSorted() {
+    if (tlDateFilter) { filterFriendTimeline(); return; }
+    ftlListPage = 0;
+    ftlOffset   = 0;
+    sendToCS({ action: 'getFriendTimelinePage', offset: 0, type: ftFilter === 'all' ? '' : ftFilter, ...tlSortParams('friends') });
 }
 
 function tlGoPage(page) {
@@ -715,7 +729,7 @@ function tlGoPage(page) {
     // Fetch this page directly from DB at absolute offset
     _tlPendingListPage = page;
     tlLoading = true;
-    sendToCS({ action: 'getTimelinePage', offset: page * 100, type: tlFilter === 'all' ? '' : tlFilter });
+    sendToCS({ action: 'getTimelinePage', offset: page * 100, type: tlFilter === 'all' ? '' : tlFilter, ...tlSortParams('personal') });
     const c = document.getElementById('tlContainer');
     if (c) c.scrollTop = 0;
 }
@@ -1274,7 +1288,7 @@ function refreshFriendTimeline() {
         c.innerHTML = sk(tlViewMode === 'list' ? 'timeline-list' : 'timeline');
     }
     if (tlDateFilter) sendToCS({ action: 'getFriendTimelineByDate', date: tlDateFilter, type: ftFilter === 'all' ? '' : ftFilter });
-    else              sendToCS({ action: 'getFriendTimeline', type: ftFilter === 'all' ? '' : ftFilter });
+    else              sendToCS({ action: 'getFriendTimeline', type: ftFilter === 'all' ? '' : ftFilter, ...tlSortParams('friends') });
 }
 
 function renderFriendTimeline(payload) {
@@ -1345,7 +1359,7 @@ function setFtFilter(f) {
     const c = document.getElementById('tlContainer');
     if (c) c.innerHTML = sk(tlViewMode === 'list' ? 'timeline-list' : 'timeline');
     if (tlDateFilter) sendToCS({ action: 'getFriendTimelineByDate', date: tlDateFilter, type: f === 'all' ? '' : f });
-    else              sendToCS({ action: 'getFriendTimeline', type: f === 'all' ? '' : f });
+    else              sendToCS({ action: 'getFriendTimeline', type: f === 'all' ? '' : f, ...tlSortParams('friends') });
 }
 
 function filterFriendTimeline() {
@@ -1389,7 +1403,7 @@ function filterFriendTimeline() {
     // Date filter: all events loaded at once → paginate client-side
     // Normal mode: server-side pagination (friendTimelineEvents = current page only)
     const ftlEventsToRender = tlDateFilter
-        ? friendTimelineEvents.slice(ftlListPage * 100, (ftlListPage + 1) * 100)
+        ? tlSortEventsLocal('friends', friendTimelineEvents).slice(ftlListPage * 100, (ftlListPage + 1) * 100)
         : friendTimelineEvents;
     const ftlTotalCount = tlDateFilter ? friendTimelineEvents.length : ftlTotal;
     const totalPages = ftlTotalCount > 0
@@ -1473,7 +1487,7 @@ function loadMoreFriendTimeline() {
     ftlLoading = true;
     const btn = document.getElementById('ftlLoadMoreBtn');
     if (btn) { btn.disabled = true; btn.innerHTML = `<span class="msi" style="font-size:16px;">hourglass_empty</span> ${esc(t('timeline.load_more.loading', 'Loading...'))}`; }
-    sendToCS({ action: 'getFriendTimelinePage', offset: ftlOffset, type: ftFilter === 'all' ? '' : ftFilter });
+    sendToCS({ action: 'getFriendTimelinePage', offset: ftlOffset, type: ftFilter === 'all' ? '' : ftFilter, ...tlSortParams('friends') });
 }
 
 function ftlGoPage(page) {
@@ -1500,7 +1514,7 @@ function ftlGoPage(page) {
     // Fetch this page directly from DB at absolute offset
     _ftlPendingListPage = page;
     ftlLoading = true;
-    sendToCS({ action: 'getFriendTimelinePage', offset: page * 100, type: ftFilter === 'all' ? '' : ftFilter });
+    sendToCS({ action: 'getFriendTimelinePage', offset: page * 100, type: ftFilter === 'all' ? '' : ftFilter, ...tlSortParams('friends') });
     const c = document.getElementById('tlContainer');
     if (c) c.scrollTop = 0;
 }

--- a/main/AppInfo.cs
+++ b/main/AppInfo.cs
@@ -2,7 +2,7 @@
 
 public static class AppInfo
 {
-    public const string Version = "2026.35.3";
+    public const string Version = "2026.35.4";
     public const string ContactEmail = "vrcn@shinyflvres.com";
     public const string Website = "vrcn.shinyflvres.com";
     public const string UserAgent = $"VRCNext/{Version} ({ContactEmail})";

--- a/main/GroupsController.cs
+++ b/main/GroupsController.cs
@@ -547,6 +547,7 @@ public class GroupsController
                             status = m["user"]?["status"]?.ToString() ?? "",
                             statusDescription = m["user"]?["statusDescription"]?.ToString() ?? "",
                             currentAvatarThumbnailImageUrl = m["user"]?["currentAvatarThumbnailImageUrl"]?.ToString() ?? "",
+                            roleIds = (m["roleIds"] as JArray)?.Select(r => r.ToString()).ToArray() ?? Array.Empty<string>(),
                         }).ToList();
                         _core.SendToJS("vrcGroupRoleMembers", new { groupId = grmGroupId, roleId = grmRoleId, members = list });
                     });

--- a/main/TimelineController.cs
+++ b/main/TimelineController.cs
@@ -648,7 +648,7 @@ public class TimelineController
                     }
                 }
 
-                var (events, hasMore) = _core.Timeline.GetEventsPaged(100, 0, tlTypeFilter);
+                var (events, hasMore) = _core.Timeline.GetEventsPaged(100, 0, tlTypeFilter, msg["sortBy"]?.ToString(), msg["sortDir"]?.ToString());
                 var total   = _core.Timeline.GetEventCount(tlTypeFilter);
                 var payload = events.Select(e => _instance.BuildTimelinePayload(e)).ToList();
                 _core.SendToJS("timelineData", new { events = payload, hasMore, offset = 0, total, type = tlTypeFilter });
@@ -675,7 +675,7 @@ public class TimelineController
             {
                 var pageOffset   = msg["offset"]?.Value<int>() ?? 0;
                 var tlTypeFilter = msg["type"]?.ToString() ?? "";
-                var (events, hasMore) = _core.Timeline.GetEventsPaged(100, pageOffset, tlTypeFilter);
+                var (events, hasMore) = _core.Timeline.GetEventsPaged(100, pageOffset, tlTypeFilter, msg["sortBy"]?.ToString(), msg["sortDir"]?.ToString());
                 var total   = _core.Timeline.GetEventCount(tlTypeFilter);
                 var payload = events.Select(e => _instance.BuildTimelinePayload(e)).ToList();
                 _core.SendToJS("timelineData", new { events = payload, hasMore, offset = pageOffset, total, type = tlTypeFilter });
@@ -738,7 +738,7 @@ public class TimelineController
             try
             {
                 var typeFilter = msg["type"]?.ToString() ?? "";
-                var (fevents, hasMore) = _core.Timeline.GetFriendEventsPaged(100, 0, typeFilter);
+                var (fevents, hasMore) = _core.Timeline.GetFriendEventsPaged(100, 0, typeFilter, msg["sortBy"]?.ToString(), msg["sortDir"]?.ToString());
                 var ftTotal  = _core.Timeline.GetFriendEventCount(typeFilter);
                 var fpayload = fevents.Select(e => _friends.BuildFriendTimelinePayload(e)).ToList();
                 _core.SendToJS("friendTimelineData", new { events = fpayload, hasMore, offset = 0, total = ftTotal, type = typeFilter });
@@ -862,7 +862,7 @@ public class TimelineController
             {
                 var pageOffset = msg["offset"]?.Value<int>() ?? 0;
                 var typeFilter = msg["type"]?.ToString() ?? "";
-                var (fevents, hasMore) = _core.Timeline.GetFriendEventsPaged(100, pageOffset, typeFilter);
+                var (fevents, hasMore) = _core.Timeline.GetFriendEventsPaged(100, pageOffset, typeFilter, msg["sortBy"]?.ToString(), msg["sortDir"]?.ToString());
                 var ftTotal  = _core.Timeline.GetFriendEventCount(typeFilter);
                 var fpayload = fevents.Select(e => _friends.BuildFriendTimelinePayload(e)).ToList();
                 _core.SendToJS("friendTimelineData", new { events = fpayload, hasMore, offset = pageOffset, total = ftTotal, type = typeFilter });


### PR DESCRIPTION
**2026.35.6**

**Player List**

* Updated the Instance Player List to use the new VRCN v2 design.
* The list is now slightly more compact and easier to navigate.
* Added World description to player list modal.
* Added World Creator to player list
* Playerlist can be now sorted with all cell filters.
* Added Hide/SHow World Panel to player list.

**Quality-of-Life Updates**

* Added **Copy Theme** to the **Show More** menu on user profiles. This copies the profile’s colors and applies them to your own profile.

**Improvements**

* The tab bar in Profile, World, Group, and Avatar modals now stays fixed while the content below it scrolls.
* Columns in the Timeline’s Personal, Friends, and Game Log lists can now be sorted by clicking their headers and reordered by dragging the handle on the right.
* Sorting applies to the entire history, not just the currently visible page. Column layouts are remembered separately for each list.

**Bug Fixes**

* Fixed column headers in Timeline lists not aligning with the content below them.
* Fixed copying images from the Photo Modal placing a local cache link on the clipboard instead of the actual image. Images can now be pasted directly into Discord, chats, and image editors.
* Fixed the heatmap in user profiles using the button color instead of the VRC+ icon color.
* Fixed an issue that prevented profile theme colors from being updated.
* Fixed the "Most visited World" progress bars on vrc+ decorated profiles.